### PR TITLE
Apply ocamlformat

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,0 +1,2 @@
+profile = default
+version = 0.23.0

--- a/dune-project
+++ b/dune-project
@@ -2,7 +2,6 @@
 (name reagents)
 
 (generate_opam_files true)
-(formatting disabled)
 
 (license BSD-3-clause)
 (maintainers "KC Sivaramakrishnan <sk826@cl.cam.ac.uk>")

--- a/examples/counter_test.ml
+++ b/examples/counter_test.ml
@@ -15,11 +15,12 @@
  *)
 
 open Printf
-module Scheduler = Sched_ws.Make(
-  struct
-    let num_domains = 1
-    let is_affine = false
-  end)
+
+module Scheduler = Sched_ws.Make (struct
+  let num_domains = 1
+  let is_affine = false
+end)
+
 module Reagents = Reagents.Make (Scheduler)
 module R_data = Reagents.Data
 module Counter = R_data.Counter
@@ -38,11 +39,14 @@ let main () =
   printf "%d\n%!" @@ run (Counter.inc c) ();
   printf "%d\n%!" @@ run (Counter.inc c) ();
   printf "%d\n%!" @@ run (Counter.dec c) ();
-  run (Counter.try_dec c >>= (fun ov ->
-    match ov with
-    | Some 1 -> ( printf "Counter is 0. Further decrement blocks the thread!\n%!";
-                  constant () )
-    | _ -> failwith "impossible")) ();
+  run
+    ( Counter.try_dec c >>= fun ov ->
+      match ov with
+      | Some 1 ->
+          printf "Counter is 0. Further decrement blocks the thread!\n%!";
+          constant ()
+      | _ -> failwith "impossible" )
+    ();
   printf "%d\n%!" @@ run (Counter.dec c) ();
   printf "Should not see this\n";
 

--- a/examples/dining_philosophers.ml
+++ b/examples/dining_philosophers.ml
@@ -17,41 +17,34 @@
 
 let print_usage_and_exit () =
   print_endline @@ "Usage: " ^ Sys.argv.(0) ^ " <num_philosophers> <num_rounds>";
-  exit(0)
+  exit 0
 
-let (num_philosophers, num_rounds) =
-  if Array.length Sys.argv < 3 then
-    print_usage_and_exit ()
+let num_philosophers, num_rounds =
+  if Array.length Sys.argv < 3 then print_usage_and_exit ()
   else
     try
-      let a = int_of_string (Sys.argv.(1)) in
-      let b = int_of_string (Sys.argv.(2)) in
-      (a,b)
-    with
-    | Failure _ -> print_usage_and_exit ()
+      let a = int_of_string Sys.argv.(1) in
+      let b = int_of_string Sys.argv.(2) in
+      (a, b)
+    with Failure _ -> print_usage_and_exit ()
 
-module S = Sched_ws.Make (
-  struct
-    let num_domains = num_philosophers
-    let is_affine = true
-  end)
+module S = Sched_ws.Make (struct
+  let num_domains = num_philosophers
+  let is_affine = true
+end)
 
 module Reagents = Reagents.Make (S)
 open Reagents
 open Channel
-
 module Sync = Reagents.Sync
-module CDL  = Sync.Countdown_latch
-
+module CDL = Sync.Countdown_latch
 open Printf
 
-type fork =
-  {drop : (unit,unit) endpoint;
-   take : (unit,unit) endpoint}
+type fork = { drop : (unit, unit) endpoint; take : (unit, unit) endpoint }
 
 let mk_fork () =
   let drop, take = mk_chan () in
-  {drop; take}
+  { drop; take }
 
 let drop f = swap f.drop
 let take f = swap f.take

--- a/examples/dune
+++ b/examples/dune
@@ -1,46 +1,42 @@
 (executables
- (names 
-   counter_test
-   dining_philosophers
-   eli_stack 
-   lock_test 
-   ref_channel
-   ref_test 
-   swap_test2
-   queue_test 
-   sat
-
-   ; Not working - usually they hang when running
-   reagent_queue_test
-   rec_test
-   stack_test
-   stack_test_compose 
-   swap_test 
-   three_way 
-   two_way
-   hw_queue
- )
+ (names
+  counter_test
+  dining_philosophers
+  eli_stack
+  lock_test
+  ref_channel
+  ref_test
+  swap_test2
+  queue_test
+  sat
+  ; Not working - usually they hang when running
+  reagent_queue_test
+  rec_test
+  stack_test
+  stack_test_compose
+  swap_test
+  three_way
+  two_way
+  hw_queue)
  (public_names
-   reagents_counter_test
-   reagents_dining_philosophers
-   reagents_eli_stack 
-   reagents_lock_test
-   reagents_ref_channel
-   reagents_ref_test
-   reagents_swap_test2
-   reagents_queue_test 
-   reagents_sat
-
-   ; Not working - usually they hang when running
-   reagents_reagent_queue_test
-   reagents_rec_test
-   reagents_stack_test ; Flakey test, sometimes passes.
-   reagents_stack_test_compose 
-   reagents_swap_test 
-   reagents_three_way 
-   reagents_two_way
-   reagents_hw_queue)
- 
+  reagents_counter_test
+  reagents_dining_philosophers
+  reagents_eli_stack
+  reagents_lock_test
+  reagents_ref_channel
+  reagents_ref_test
+  reagents_swap_test2
+  reagents_queue_test
+  reagents_sat
+  ; Not working - usually they hang when running
+  reagents_reagent_queue_test
+  reagents_rec_test
+  reagents_stack_test ; Flakey test, sometimes passes.
+  reagents_stack_test_compose
+  reagents_swap_test
+  reagents_three_way
+  reagents_two_way
+  reagents_hw_queue)
  (libraries unix reagents)
  (flags
   (:standard -w -32))

--- a/examples/eli_stack.ml
+++ b/examples/eli_stack.ml
@@ -16,21 +16,18 @@
 
 let print_usage_and_exit () =
   print_endline @@ "Usage: " ^ Sys.argv.(0) ^ " <num_domains> <num_items>";
-  exit(0)
+  exit 0
 
-let (num_doms, num_items) =
-  if Array.length Sys.argv < 3 then
-    print_usage_and_exit ()
+let num_doms, num_items =
+  if Array.length Sys.argv < 3 then print_usage_and_exit ()
   else
     try
-      let a = int_of_string (Sys.argv.(1)) in
-      let b = int_of_string (Sys.argv.(2)) in
-      (a,b)
-    with
-    | Failure _ -> print_usage_and_exit ()
+      let a = int_of_string Sys.argv.(1) in
+      let b = int_of_string Sys.argv.(2) in
+      (a, b)
+    with Failure _ -> print_usage_and_exit ()
 
 let items_per_dom = num_items / num_doms
-
 let () = Printf.printf "items_per_domain = %d\n%!" items_per_dom
 
 module M = struct
@@ -39,28 +36,27 @@ module M = struct
 end
 
 module S = Sched_ws.Make (M)
-
 module Reagents = Reagents.Make (S)
 open Reagents
-
 open Printf
 
 module type STACK = sig
   type 'a t
+
   val create : unit -> 'a t
-  val push   : 'a t -> 'a -> unit
-  val pop    : 'a t -> 'a option
+  val push : 'a t -> 'a -> unit
+  val pop : 'a t -> 'a option
 end
 
 module type RSTACK = sig
   type 'a t
-  val create  : unit -> 'a t
-  val push    : 'a t -> ('a, unit) Reagents.t
+
+  val create : unit -> 'a t
+  val push : 'a t -> ('a, unit) Reagents.t
   val try_pop : 'a t -> (unit, 'a option) Reagents.t
 end
 
 module MakeS (RQ : RSTACK) : STACK = struct
-
   type 'a t = 'a RQ.t
 
   let create = RQ.create
@@ -70,8 +66,8 @@ end
 
 module Benchmark = struct
   let get_mean_sd l =
-    let get_mean l = (List.fold_right (fun a v -> a +. v) l 0.) /.
-                (float_of_int @@ List.length l)
+    let get_mean l =
+      List.fold_right (fun a v -> a +. v) l 0. /. (float_of_int @@ List.length l)
     in
     let mean = get_mean l in
     let sd = get_mean @@ List.map (fun v -> abs_float (v -. mean) ** 2.) l in
@@ -79,40 +75,47 @@ module Benchmark = struct
 
   let benchmark f n =
     let rec run acc = function
-    | 0 -> acc
-    | n ->
-        let t1 = Unix.gettimeofday () in
-        let () = f () in
-        let d = Unix.gettimeofday () -. t1 in
-        run (d::acc) (n-1)
+      | 0 -> acc
+      | n ->
+          let t1 = Unix.gettimeofday () in
+          let () = f () in
+          let d = Unix.gettimeofday () -. t1 in
+          run (d :: acc) (n - 1)
     in
     let r = run [] n in
     get_mean_sd r
 end
 
 module Sync = Reagents.Sync
-module CDL  = Sync.Countdown_latch
+module CDL = Sync.Countdown_latch
 
 module Test (Q : STACK) = struct
-
   let run num_doms items_per_domain =
     let q : int Q.t = Q.create () in
     let b = CDL.create num_doms in
     (* initialize work *)
     let rec produce = function
-      | 0 -> (); printf "[%d] production complete\n%!" (S.get_qid ())
-      | i -> Q.push q i; produce (i-1)
+      | 0 ->
+          ();
+          printf "[%d] production complete\n%!" (S.get_qid ())
+      | i ->
+          Q.push q i;
+          produce (i - 1)
     in
     let rec consume i =
       match Q.pop q with
-      | None -> (); print_string @@ sprintf "[%d] consumed=%d\n%!" (S.get_qid ()) i
-      | Some _ -> consume (i+1)
+      | None ->
+          ();
+          print_string @@ sprintf "[%d] consumed=%d\n%!" (S.get_qid ()) i
+      | Some _ -> consume (i + 1)
     in
     for i = 1 to num_doms - 1 do
-      S.fork_on (fun () ->
-        produce items_per_domain;
-        consume 0;
-        run (CDL.count_down b) ()) i
+      S.fork_on
+        (fun () ->
+          produce items_per_domain;
+          consume 0;
+          run (CDL.count_down b) ())
+        i
     done;
     produce items_per_domain;
     consume 0;
@@ -125,9 +128,10 @@ module Data = Reagents.Data
 let num_runs = 10
 
 let main () =
-  let module M = Test(MakeS(Data.Elimination_stack)) in
-  let (m,sd) = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 10 in
-  printf "Elimination stack: mean = %f, sd = %f tp=%f\n%!" m sd (float_of_int num_items /. m)
+  let module M = Test (MakeS (Data.Elimination_stack)) in
+  let m, sd = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 10 in
+  printf "Elimination stack: mean = %f, sd = %f tp=%f\n%!" m sd
+    (float_of_int num_items /. m)
 
 let () = S.run main
 let () = Unix.sleep 1

--- a/examples/hw_queue.ml
+++ b/examples/hw_queue.ml
@@ -16,18 +16,16 @@
 
 let print_usage_and_exit () =
   print_endline @@ "Usage: " ^ Sys.argv.(0) ^ " <num_domains> <num_items>";
-  exit(0)
+  exit 0
 
-let (num_doms, num_items) =
-  if Array.length Sys.argv < 3 then
-    print_usage_and_exit ()
+let num_doms, num_items =
+  if Array.length Sys.argv < 3 then print_usage_and_exit ()
   else
     try
-      let a = int_of_string (Sys.argv.(1)) in
-      let b = int_of_string (Sys.argv.(2)) in
-      (a,b)
-    with
-    | Failure _ -> print_usage_and_exit ()
+      let a = int_of_string Sys.argv.(1) in
+      let b = int_of_string Sys.argv.(2) in
+      (a, b)
+    with Failure _ -> print_usage_and_exit ()
 
 let items_per_dom = num_items / num_doms
 
@@ -35,39 +33,42 @@ module M = struct
   let num_domains = num_doms
   let is_affine = false
 end
+
 module S = Sched_ws.Make (M)
 
-let () = Printf.printf "[%d] items_per_domain = %d\n%!" (S.get_qid ()) items_per_dom
+let () =
+  Printf.printf "[%d] items_per_domain = %d\n%!" (S.get_qid ()) items_per_dom
 
 let id_str () = Printf.sprintf "%d:%d" (S.get_qid ()) (S.get_tid ())
 
 module type BARRIER = sig
   type t
+
   val create : int -> t
   val finish : t -> unit
 end
 
 module Reagents = Reagents.Make (S)
 open Reagents
-
 open Printf
 
 module type QUEUE = sig
   type 'a t
+
   val create : unit -> 'a t
-  val push   : 'a t -> 'a -> unit
-  val pop    : 'a t -> 'a option
+  val push : 'a t -> 'a -> unit
+  val pop : 'a t -> 'a option
 end
 
 module type RQUEUE = sig
   type 'a t
-  val create  : unit -> 'a t
-  val push    : 'a t -> ('a, unit) Reagents.t
+
+  val create : unit -> 'a t
+  val push : 'a t -> ('a, unit) Reagents.t
   val try_pop : 'a t -> (unit, 'a option) Reagents.t
 end
 
 module MakeQ (RQ : RQUEUE) : QUEUE = struct
-
   type 'a t = 'a RQ.t
 
   let create = RQ.create
@@ -77,8 +78,8 @@ end
 
 module Benchmark = struct
   let get_mean_sd l =
-    let get_mean l = (List.fold_right (fun a v -> a +. v) l 0.) /.
-                (float_of_int @@ List.length l)
+    let get_mean l =
+      List.fold_right (fun a v -> a +. v) l 0. /. (float_of_int @@ List.length l)
     in
     let mean = get_mean l in
     let sd = get_mean @@ List.map (fun v -> abs_float (v -. mean) ** 2.) l in
@@ -86,39 +87,44 @@ module Benchmark = struct
 
   let benchmark f n =
     let rec run acc = function
-    | 0 -> acc
-    | n ->
-        let t1 = Unix.gettimeofday () in
-        let () = f () in
-        let d = Unix.gettimeofday () -. t1 in
-        run (d::acc) (n-1)
+      | 0 -> acc
+      | n ->
+          let t1 = Unix.gettimeofday () in
+          let () = f () in
+          let d = Unix.gettimeofday () -. t1 in
+          run (d :: acc) (n - 1)
     in
     let r = run [] n in
     get_mean_sd r
 end
 
-module CDL  = Sync.Countdown_latch
+module CDL = Sync.Countdown_latch
 
 module Test (Q : QUEUE) = struct
-
   let run num_doms items_per_domain =
     let q : int Q.t = Q.create () in
     let b = CDL.create num_doms in
     (* initialize work *)
     let rec produce = function
       | 0 -> ()
-      | i -> Q.push q i; produce (i-1)
+      | i ->
+          Q.push q i;
+          produce (i - 1)
     in
     let rec consume i =
       match Q.pop q with
-      | None -> (); printf "consumed=%d\n%!" i
-      | Some _ -> consume (i+1)
+      | None ->
+          ();
+          printf "consumed=%d\n%!" i
+      | Some _ -> consume (i + 1)
     in
     for i = 1 to num_doms - 1 do
-      S.fork_on (fun () ->
-        produce items_per_domain;
-        consume 0;
-        run (CDL.count_down b) ()) i
+      S.fork_on
+        (fun () ->
+          produce items_per_domain;
+          consume 0;
+          run (CDL.count_down b) ())
+        i
     done;
     produce items_per_domain;
     consume 0;
@@ -127,9 +133,10 @@ module Test (Q : QUEUE) = struct
 end
 
 let main () =
-  let module M = Test(Lockfree.Michael_scott_queue) in
-  let (m,sd) = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
-  printf "Hand-written Lockfree.MSQueue: mean = %f, sd = %f tp=%f\n%!" m sd (float_of_int num_items /. m)
+  let module M = Test (Lockfree.Michael_scott_queue) in
+  let m, sd = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
+  printf "Hand-written Lockfree.MSQueue: mean = %f, sd = %f tp=%f\n%!" m sd
+    (float_of_int num_items /. m)
 
 let () = S.run main
 let () = Unix.sleep 1

--- a/examples/lock_queue.mli
+++ b/examples/lock_queue.mli
@@ -1,4 +1,5 @@
 type 'a t = ('a list * 'a list) ref * bool Atomic.t
+
 val max_iters : int
 val lock : bool Atomic.t -> unit
 val unlock : bool Atomic.t -> unit

--- a/examples/lock_stack.mli
+++ b/examples/lock_stack.mli
@@ -1,4 +1,5 @@
 type 'a t = 'a list ref * bool Atomic.t
+
 val max_iters : int
 val lock : bool Atomic.t -> unit
 val unlock : bool Atomic.t -> unit

--- a/examples/lock_test.ml
+++ b/examples/lock_test.ml
@@ -15,15 +15,15 @@
  *)
 
 open Printf
-module Scheduler = Sched_ws.Make(
-  struct
-    let num_domains = 1
-    let is_affine = false
-  end)
+
+module Scheduler = Sched_ws.Make (struct
+  let num_domains = 1
+  let is_affine = false
+end)
+
 module Reagents = Reagents.Make (Scheduler)
 open Scheduler
 open Reagents
-
 module Sync = Reagents.Sync
 module Lock = Sync.Lock
 module CV = Sync.Condition_variable
@@ -38,19 +38,19 @@ let main () =
   let l = Lock.create () in
   let cv = CV.create () in
   run (Lock.acq l) ();
-  printf "[%s] Acquired lock\n" (id_str());
+  printf "[%s] Acquired lock\n" (id_str ());
   fork (fun () ->
-    printf "[%s] Starting waker thread\n" (id_str ());
-    run (Lock.acq l) ();
-    printf "[%s] Acquired lock\n" (id_str());
-    CV.signal cv;
-    printf "[%s] Signal send\n" (id_str());
-    assert (run (Lock.rel l) ());
-    printf "[%s] Released lock\n" (id_str()));
-  printf "[%s] Going to wait on condition variable\n" (id_str());
+      printf "[%s] Starting waker thread\n" (id_str ());
+      run (Lock.acq l) ();
+      printf "[%s] Acquired lock\n" (id_str ());
+      CV.signal cv;
+      printf "[%s] Signal send\n" (id_str ());
+      assert (run (Lock.rel l) ());
+      printf "[%s] Released lock\n" (id_str ()));
+  printf "[%s] Going to wait on condition variable\n" (id_str ());
   assert (CV.wait l cv);
-  printf "[%s] Woken up..\n" (id_str());
+  printf "[%s] Woken up..\n" (id_str ());
   assert (run (Lock.rel l) ());
-  printf "[%s] Released lock\n" (id_str())
+  printf "[%s] Released lock\n" (id_str ())
 
 let () = Scheduler.run main

--- a/examples/queue_test.ml
+++ b/examples/queue_test.ml
@@ -16,23 +16,21 @@
 
 let print_usage_and_exit () =
   print_endline @@ "Usage: " ^ Sys.argv.(0) ^ " <num_domains> <num_items>";
-  exit(0)
+  exit 0
 
-let (num_doms, num_items) =
-  if Array.length Sys.argv < 3 then
-    print_usage_and_exit ()
+let num_doms, num_items =
+  if Array.length Sys.argv < 3 then print_usage_and_exit ()
   else
     try
-      let a = int_of_string (Sys.argv.(1)) in
-      let b = int_of_string (Sys.argv.(2)) in
-      (a,b)
-    with
-    | Failure _ -> print_usage_and_exit ()
+      let a = int_of_string Sys.argv.(1) in
+      let b = int_of_string Sys.argv.(2) in
+      (a, b)
+    with Failure _ -> print_usage_and_exit ()
 
 let () =
-  if num_doms mod 2 <> 0 then
-    (print_endline @@ "<num_domains> must be multiple of 2";
-     exit 0)
+  if num_doms mod 2 <> 0 then (
+    print_endline @@ "<num_domains> must be multiple of 2";
+    exit 0)
 
 let items_per_dom = num_items / num_doms
 
@@ -40,39 +38,42 @@ module M = struct
   let num_domains = num_doms
   let is_affine = false
 end
+
 module S = Sched_ws.Make (M)
 
-let () = Printf.printf "[%d] items_per_domain = %d\n%!" (S.get_qid ()) items_per_dom
+let () =
+  Printf.printf "[%d] items_per_domain = %d\n%!" (S.get_qid ()) items_per_dom
 
 let id_str () = Printf.sprintf "%d:%d" (S.get_qid ()) (S.get_tid ())
 
 module type BARRIER = sig
   type t
+
   val create : int -> t
   val finish : t -> unit
 end
 
 module Reagents = Reagents.Make (S)
 open Reagents
-
 open Printf
 
 module type QUEUE = sig
   type 'a t
+
   val create : unit -> 'a t
-  val push   : 'a t -> 'a -> unit
-  val pop    : 'a t -> 'a option
+  val push : 'a t -> 'a -> unit
+  val pop : 'a t -> 'a option
 end
 
 module type RQUEUE = sig
   type 'a t
-  val create  : unit -> 'a t
-  val push    : 'a t -> ('a, unit) Reagents.t
+
+  val create : unit -> 'a t
+  val push : 'a t -> ('a, unit) Reagents.t
   val try_pop : 'a t -> (unit, 'a option) Reagents.t
 end
 
 module MakeQ (RQ : RQUEUE) : QUEUE = struct
-
   type 'a t = 'a RQ.t
 
   let create = RQ.create
@@ -82,8 +83,8 @@ end
 
 module Benchmark = struct
   let get_mean_sd l =
-    let get_mean l = (List.fold_right (fun a v -> a +. v) l 0.) /.
-                (float_of_int @@ List.length l)
+    let get_mean l =
+      List.fold_right (fun a v -> a +. v) l 0. /. (float_of_int @@ List.length l)
     in
     let mean = get_mean l in
     let sd = get_mean @@ List.map (fun v -> abs_float (v -. mean) ** 2.) l in
@@ -91,41 +92,42 @@ module Benchmark = struct
 
   let benchmark f n =
     let rec run acc = function
-    | 0 -> acc
-    | n ->
-        let t1 = Unix.gettimeofday () in
-        let () = f () in
-        let d = Unix.gettimeofday () -. t1 in
-        run (d::acc) (n-1)
+      | 0 -> acc
+      | n ->
+          let t1 = Unix.gettimeofday () in
+          let () = f () in
+          let d = Unix.gettimeofday () -. t1 in
+          run (d :: acc) (n - 1)
     in
     let r = run [] n in
     get_mean_sd r
 end
 
 module Sync = Reagents.Sync
-module CDL  = Sync.Countdown_latch
+module CDL = Sync.Countdown_latch
 
 module Test (Q : QUEUE) = struct
-
   let run num_doms items_per_domain =
     let q : int Q.t = Q.create () in
     let b = CDL.create num_doms in
     (* initialize work *)
     let rec produce = function
       | 0 -> ()
-      | i -> Q.push q i; produce (i-1)
+      | i ->
+          Q.push q i;
+          produce (i - 1)
     in
     let rec consume i =
       match Q.pop q with
       | None -> () (* printf "consumed=%d\n%!" i *)
-      | Some _ -> consume (i+1)
+      | Some _ -> consume (i + 1)
     in
     for i = 1 to num_doms - 1 do
-      S.fork_on (fun () ->
-        if i mod 2 == 0
-        then produce items_per_domain
-        else consume 0;
-        run (CDL.count_down b) ()) i
+      S.fork_on
+        (fun () ->
+          if i mod 2 == 0 then produce items_per_domain else consume 0;
+          run (CDL.count_down b) ())
+        i
     done;
     produce items_per_domain;
     run (CDL.count_down b) ();
@@ -135,17 +137,19 @@ end
 module Data = Reagents.Data
 
 let main () =
-  let module M = Test(Lock_queue) in
-  let (m,sd) = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
-  printf "Lock_queue : mean = %f, sd = %f tp=%f\n%!" m sd (float_of_int num_items /. m);
+  let module M = Test (Lock_queue) in
+  let m, sd = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
+  printf "Lock_queue : mean = %f, sd = %f tp=%f\n%!" m sd
+    (float_of_int num_items /. m);
 
-  let module M = Test(MakeQ(Data.MichaelScott_queue)) in
-  let (m,sd) = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
-  printf "Reagent Lockfree.MSQueue: mean = %f, sd = %f tp=%f\n%!" m sd (float_of_int num_items /. m);
+  let module M = Test (MakeQ (Data.MichaelScott_queue)) in
+  let m, sd = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
+  printf "Reagent Lockfree.MSQueue: mean = %f, sd = %f tp=%f\n%!" m sd
+    (float_of_int num_items /. m);
 
-  let module M = Test(Lockfree.Michael_scott_queue) in
-  let (m,sd) = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
-  printf "Hand-written Lockfree.MSQueue: mean = %f, sd = %f tp=%f\n%!" m sd (float_of_int num_items /. m)
-
+  let module M = Test (Lockfree.Michael_scott_queue) in
+  let m, sd = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
+  printf "Hand-written Lockfree.MSQueue: mean = %f, sd = %f tp=%f\n%!" m sd
+    (float_of_int num_items /. m)
 
 let () = S.run main

--- a/examples/reagent_queue_test.ml
+++ b/examples/reagent_queue_test.ml
@@ -16,18 +16,16 @@
 
 let print_usage_and_exit () =
   print_endline @@ "Usage: " ^ Sys.argv.(0) ^ " <num_domains> <num_items>";
-  exit(0)
+  exit 0
 
-let (num_doms, num_items) =
-  if Array.length Sys.argv < 3 then
-    print_usage_and_exit ()
+let num_doms, num_items =
+  if Array.length Sys.argv < 3 then print_usage_and_exit ()
   else
     try
-      let a = int_of_string (Sys.argv.(1)) in
-      let b = int_of_string (Sys.argv.(2)) in
-      (a,b)
-    with
-    | Failure _ -> print_usage_and_exit ()
+      let a = int_of_string Sys.argv.(1) in
+      let b = int_of_string Sys.argv.(2) in
+      (a, b)
+    with Failure _ -> print_usage_and_exit ()
 
 let items_per_dom = num_items / num_doms
 
@@ -35,39 +33,42 @@ module M = struct
   let num_domains = num_doms
   let is_affine = false
 end
+
 module S = Sched_ws.Make (M)
 
-let () = Printf.printf "[%d] items_per_domain = %d\n%!" (S.get_qid ()) items_per_dom
+let () =
+  Printf.printf "[%d] items_per_domain = %d\n%!" (S.get_qid ()) items_per_dom
 
 let id_str () = Printf.sprintf "%d:%d" (S.get_qid ()) (S.get_tid ())
 
 module type BARRIER = sig
   type t
+
   val create : int -> t
   val finish : t -> unit
 end
 
 module Reagents = Reagents.Make (S)
 open Reagents
-
 open Printf
 
 module type QUEUE = sig
   type 'a t
+
   val create : unit -> 'a t
-  val push   : 'a t -> 'a -> unit
-  val pop    : 'a t -> 'a option
+  val push : 'a t -> 'a -> unit
+  val pop : 'a t -> 'a option
 end
 
 module type RQUEUE = sig
   type 'a t
-  val create  : unit -> 'a t
-  val push    : 'a t -> ('a, unit) Reagents.t
+
+  val create : unit -> 'a t
+  val push : 'a t -> ('a, unit) Reagents.t
   val try_pop : 'a t -> (unit, 'a option) Reagents.t
 end
 
 module MakeQ (RQ : RQUEUE) : QUEUE = struct
-
   type 'a t = 'a RQ.t
 
   let create = RQ.create
@@ -77,8 +78,8 @@ end
 
 module Benchmark = struct
   let get_mean_sd l =
-    let get_mean l = (List.fold_right (fun a v -> a +. v) l 0.) /.
-                (float_of_int @@ List.length l)
+    let get_mean l =
+      List.fold_right (fun a v -> a +. v) l 0. /. (float_of_int @@ List.length l)
     in
     let mean = get_mean l in
     let sd = get_mean @@ List.map (fun v -> abs_float (v -. mean) ** 2.) l in
@@ -86,40 +87,43 @@ module Benchmark = struct
 
   let benchmark f n =
     let rec run acc = function
-    | 0 -> acc
-    | n ->
-        let t1 = Unix.gettimeofday () in
-        let () = f () in
-        let d = Unix.gettimeofday () -. t1 in
-        run (d::acc) (n-1)
+      | 0 -> acc
+      | n ->
+          let t1 = Unix.gettimeofday () in
+          let () = f () in
+          let d = Unix.gettimeofday () -. t1 in
+          run (d :: acc) (n - 1)
     in
     let r = run [] n in
     get_mean_sd r
 end
 
 module Sync = Reagents.Sync
-module CDL  = Sync.Countdown_latch
+module CDL = Sync.Countdown_latch
 
 module Test (Q : QUEUE) = struct
-
   let run num_doms items_per_domain =
     let q : int Q.t = Q.create () in
     let b = CDL.create num_doms in
     (* initialize work *)
     let rec produce = function
       | 0 -> ()
-      | i -> Q.push q i; produce (i-1)
+      | i ->
+          Q.push q i;
+          produce (i - 1)
     in
     let rec consume i =
       match Q.pop q with
       | None -> () (* printf "consumed=%d\n%!" i *)
-      | Some _ -> consume (i+1)
+      | Some _ -> consume (i + 1)
     in
     for i = 1 to num_doms - 1 do
-      S.fork_on (fun () ->
-        produce items_per_domain;
-        consume 0;
-        run (CDL.count_down b) ()) i
+      S.fork_on
+        (fun () ->
+          produce items_per_domain;
+          consume 0;
+          run (CDL.count_down b) ())
+        i
     done;
     produce items_per_domain;
     consume 0;
@@ -130,9 +134,10 @@ end
 module Data = Reagents.Data
 
 let main () =
-  let module M = Test(MakeQ(Data.MichaelScott_queue)) in
-  let (m,sd) = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
-  printf "Reagent Lockfree.MSQueue: mean = %f, sd = %f tp=%f\n%!" m sd (float_of_int num_items /. m)
+  let module M = Test (MakeQ (Data.MichaelScott_queue)) in
+  let m, sd = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
+  printf "Reagent Lockfree.MSQueue: mean = %f, sd = %f tp=%f\n%!" m sd
+    (float_of_int num_items /. m)
 
 let () = S.run main
 let () = Unix.sleep 1

--- a/examples/rec_test.ml
+++ b/examples/rec_test.ml
@@ -1,54 +1,61 @@
-module Scheduler = Sched_ws.Make(
-  struct
-    let num_domains = 4
-    let is_affine = false
-  end)
-module Reagents = Reagents.Make(Scheduler)
+module Scheduler = Sched_ws.Make (struct
+  let num_domains = 4
+  let is_affine = false
+end)
+
+module Reagents = Reagents.Make (Scheduler)
 open Scheduler
 open Reagents
-
 module Sync = Reagents.Sync
-module RLock = Sync.Recursive_lock(Scheduler)
+module RLock = Sync.Recursive_lock (Scheduler)
 module CDL = Sync.Countdown_latch
 
 let flip f a b = f b a
 
 let rec lock_and_call l i =
-  flip run () @@ RLock.acq l ;
-  callback l i ;
+  flip run () @@ RLock.acq l;
+  callback l i;
   ignore (flip run () @@ RLock.rel l)
+
 and callback l i = if i > 0 then lock_and_call l (i - 1)
 
 let main () =
   let l = RLock.create () in
 
-  fork_on (fun () ->
-      run (RLock.acq l) () ;
-      lock_and_call l 1 ;
-      ignore (run (RLock.rel l) ())) 2;
+  fork_on
+    (fun () ->
+      run (RLock.acq l) ();
+      lock_and_call l 1;
+      ignore (run (RLock.rel l) ()))
+    2;
 
   let cdl = CDL.create (100 + (100 * 2)) in
   (* ... *)
   for i = 0 to 99 do
-    fork_on (fun () -> lock_and_call l 100 ; run (CDL.count_down cdl) ()) (i mod 4)
-  done ;
+    fork_on
+      (fun () ->
+        lock_and_call l 100;
+        run (CDL.count_down cdl) ())
+      (i mod 4)
+  done;
   (* ... *)
   for i = 0 to 99 do
-    fork_on (fun () ->
-              run (RLock.acq l) () ;
-              if run (RLock.try_acq l) ()
-              then ignore @@ run (RLock.rel l) ()
-              else assert false ;
-              ignore @@ run (RLock.rel l) () ;
-              run (CDL.count_down cdl) ())
-            (i mod 4);
-    fork_on (fun () ->
-              if run (RLock.try_acq l) () then
-                (lock_and_call l 100 ;
-                ignore (run (RLock.rel l) ())) ;
-              run (CDL.count_down cdl) ())
-            (i mod 4)
-  done ;
+    fork_on
+      (fun () ->
+        run (RLock.acq l) ();
+        if run (RLock.try_acq l) () then ignore @@ run (RLock.rel l) ()
+        else assert false;
+        ignore @@ run (RLock.rel l) ();
+        run (CDL.count_down cdl) ())
+      (i mod 4);
+    fork_on
+      (fun () ->
+        if run (RLock.try_acq l) () then (
+          lock_and_call l 100;
+          ignore (run (RLock.rel l) ()));
+        run (CDL.count_down cdl) ())
+      (i mod 4)
+  done;
 
   run (CDL.await cdl) ()
 

--- a/examples/ref_channel.ml
+++ b/examples/ref_channel.ml
@@ -1,15 +1,15 @@
 module type REF_CHANNEL = sig
-  type ('a,'b) reagent
+  type ('a, 'b) reagent
   type 'a channel
+
   val mk_chan : unit -> 'a channel
-  val send : 'a channel -> ('a,unit) reagent
-  val recv : 'a channel -> (unit,'a) reagent
+  val send : 'a channel -> ('a, unit) reagent
+  val recv : 'a channel -> (unit, 'a) reagent
 end
 
-module Ref_channel(Reagents : Reagents.S)
-  : REF_CHANNEL with type ('a,'b) reagent = ('a,'b) Reagents.t = struct
-
-  type ('a,'b) reagent = ('a,'b) Reagents.t
+module Ref_channel (Reagents : Reagents.S) :
+  REF_CHANNEL with type ('a, 'b) reagent = ('a, 'b) Reagents.t = struct
+  type ('a, 'b) reagent = ('a, 'b) Reagents.t
 
   open Reagents
 
@@ -19,27 +19,24 @@ module Ref_channel(Reagents : Reagents.S)
 
   let send r =
     Ref.upd r (fun st v ->
-      match st with
-      | None -> Some (Some v, ())
-      | _ -> None)
+        match st with None -> Some (Some v, ()) | _ -> None)
 
   let recv r =
     Ref.upd r (fun st _ ->
-      match st with
-      | None -> None
-      | Some v -> Some (None, v))
- end
+        match st with None -> None | Some v -> Some (None, v))
+end
 
 open Printf
-module Scheduler = Sched_ws.Make(
-  struct
-    let num_domains = 1
-    let is_affine = false
-  end)
+
+module Scheduler = Sched_ws.Make (struct
+  let num_domains = 1
+  let is_affine = false
+end)
+
 module Reagents = Reagents.Make (Scheduler)
 open Scheduler
 open Reagents
-module Channel = Ref_channel(Reagents)
+module Channel = Ref_channel (Reagents)
 open Channel
 
 let id_str () = sprintf "%d:%d" (get_qid ()) (get_tid ())

--- a/examples/ref_test.ml
+++ b/examples/ref_test.ml
@@ -15,10 +15,12 @@
  *)
 
 open Printf
-module Scheduler = Sched_ws.Make(struct
-    let num_domains = 1
-    let is_affine = false
-  end)
+
+module Scheduler = Sched_ws.Make (struct
+  let num_domains = 1
+  let is_affine = false
+end)
+
 module Reagents = Reagents.Make (Scheduler)
 open Scheduler
 open Reagents
@@ -34,8 +36,12 @@ let main () =
   let r = mk_ref 0 in
   (* [foo] should be pure. Printing for illustrative purposes. *)
   let foo ov () =
-    if ov = 0 then ( printf "[%s] Saw 0. Blocking..\n%!" (id_str ()); None )
-    else ( printf "[%s] Saw 1. Success. Set to 2.\n%!" (id_str ()); Some (2, ()) )
+    if ov = 0 then (
+      printf "[%s] Saw 0. Blocking..\n%!" (id_str ());
+      None)
+    else (
+      printf "[%s] Saw 1. Success. Set to 2.\n%!" (id_str ());
+      Some (2, ()))
   in
   fork (fun () -> run (upd r foo) ());
   run (cas r 0 1) ();
@@ -46,9 +52,12 @@ let main () =
   printf "**** Test 2 ****\n%!";
   let test2_rg =
     read r >>= fun i ->
-    if i <> 3
-    then ( printf "[%s] Saw %d. Expecting 3. Blocking..\n%!" (id_str()) i; never )
-    else ( printf "[%s] Saw 3. Success.\n%!" (id_str ()); constant () )
+    if i <> 3 then (
+      printf "[%s] Saw %d. Expecting 3. Blocking..\n%!" (id_str ()) i;
+      never)
+    else (
+      printf "[%s] Saw 3. Success.\n%!" (id_str ());
+      constant ())
   in
   fork (run test2_rg);
   run (cas r 2 3) ();

--- a/examples/sat.ml
+++ b/examples/sat.ml
@@ -1,8 +1,8 @@
-module Scheduler = Sched_ws.Make(
-  struct
-    let num_domains = 1
-    let is_affine = false
-  end)
+module Scheduler = Sched_ws.Make (struct
+  let num_domains = 1
+  let is_affine = false
+end)
+
 module Reagents = Reagents.Make (Scheduler)
 open Reagents
 
@@ -10,7 +10,7 @@ let n = 20
 
 let rec mk_answer acc = function
   | 0 -> acc
-  | n -> mk_answer (Random.bool()::acc) (n-1)
+  | n -> mk_answer (Random.bool () :: acc) (n - 1)
 
 let answer = mk_answer [] n
 
@@ -18,12 +18,11 @@ let rec make acc = function
   | 0 -> acc
   | n ->
       let r = constant true <+> constant false in
-      make (r::acc) (n-1)
+      make (r :: acc) (n - 1)
 
 let rec join acc = function
   | [] -> constant (List.rev acc)
-  | x::xs ->
-      x >>= (fun v -> join (v::acc) xs)
+  | x :: xs -> x >>= fun v -> join (v :: acc) xs
 
 let join l = join [] l
 
@@ -32,10 +31,10 @@ let main () =
     join (make [] n) >>= fun l ->
     (* instead of l = answer, assume `eval_formula l formula` where
        eval_formula : input:bool list -> formula -> bool *)
-    if l = answer then begin
+    if l = answer then (
       Printf.printf "SAT\n%!";
-      constant ()
-    end else never
+      constant ())
+    else never
   in
   run r ()
 

--- a/examples/sched_ws.ml
+++ b/examples/sched_ws.ml
@@ -20,27 +20,25 @@ module type S = sig
   type 'a cont
 
   val suspend : ('a cont -> 'a option) -> 'a
-  val resume  : 'a cont -> 'a -> unit
-  val fork    : (unit -> unit) -> unit
+  val resume : 'a cont -> 'a -> unit
+  val fork : (unit -> unit) -> unit
   val fork_on : (unit -> unit) -> queue_id -> unit
-  val yield   : unit -> unit
+  val yield : unit -> unit
   val get_qid : unit -> queue_id
   val get_tid : unit -> thread_id
-  val run     : (unit -> unit) -> unit
+  val run : (unit -> unit) -> unit
 end
 
 module Make (S : sig
-    val num_domains : int
-    val is_affine: bool
-  end) : S = struct
-
+  val num_domains : int
+  val is_affine : bool
+end) : S = struct
   open Effect
   open Effect.Deep
 
   type queue_id = int
   type thread_id = int
   type 'a cont = ('a, unit) continuation * queue_id
-
   type _ Effect.t += Suspend : ('a cont -> 'a option) -> 'a Effect.t
   type _ Effect.t += Resume : ('a cont * 'a) -> unit Effect.t
   type _ Effect.t += Fork : (unit -> unit) -> unit Effect.t
@@ -48,125 +46,129 @@ module Make (S : sig
   type _ Effect.t += Yield : unit Effect.t
   type _ Effect.t += GetTid : thread_id Effect.t
 
-  let suspend f     = perform (Suspend f)
-  let resume t v    = perform (Resume (t, v))
-  let fork f        = perform (Fork f)
+  let suspend f = perform (Suspend f)
+  let resume t v = perform (Resume (t, v))
+  let fork f = perform (Fork f)
   let fork_on f qid = perform (ForkOn (f, qid))
-  let yield ()      = perform Yield
-  let get_tid ()    = perform GetTid
-
+  let yield () = perform Yield
+  let get_tid () = perform GetTid
   let num_threads = Atomic.make 0
 
-  let queues = Array.init S.num_domains (fun _ -> Lockfree.Michael_scott_queue.create ())
+  let queues =
+    Array.init S.num_domains (fun _ -> Lockfree.Michael_scott_queue.create ())
 
   let get_queue qid = Array.get queues qid
-
   let dom_id_to_qid_map = Hashtbl.create S.num_domains
   let first_unmapped_qid = ref 0
 
-  let add_dom_to_qid_map (dom_id:Domain.id) =
-    Hashtbl.add dom_id_to_qid_map dom_id (!first_unmapped_qid);
+  let add_dom_to_qid_map (dom_id : Domain.id) =
+    Hashtbl.add dom_id_to_qid_map dom_id !first_unmapped_qid;
     first_unmapped_qid := !first_unmapped_qid + 1
 
   let get_qid () =
     let b = Lockfree.Backoff.create () in
-    let rec loop () = try Hashtbl.find dom_id_to_qid_map (Domain.self()) with
-                      | Not_found -> Lockfree.Backoff.once b; loop ()
-    in loop ()
+    let rec loop () =
+      try Hashtbl.find dom_id_to_qid_map (Domain.self ())
+      with Not_found ->
+        Lockfree.Backoff.once b;
+        loop ()
+    in
+    loop ()
 
   let fresh_tid () = Oo.id (object end)
-
   let enqueue c qid = Lockfree.Michael_scott_queue.push (get_queue qid) c
 
   let dequeue qid =
     let b = Lockfree.Backoff.create () in
     let queue = get_queue qid in
-    let rec loop () = match Lockfree.Michael_scott_queue.pop queue with
+    let rec loop () =
+      match Lockfree.Michael_scott_queue.pop queue with
       | Some k -> k ()
       | None ->
-          if Atomic.get num_threads <> 0 then
-            ( Lockfree.Backoff.once b ; loop () )
-    in loop ()
+          if Atomic.get num_threads <> 0 then (
+            Lockfree.Backoff.once b;
+            loop ())
+    in
+    loop ()
 
-  let rec spawn f (tid:thread_id) =
+  let rec spawn f (tid : thread_id) =
     let current_qid = get_qid () in
-      Atomic.incr num_threads;
-      (* begin *)
-        match_with f () {
-            retc = (fun () -> Atomic.decr num_threads; dequeue current_qid;);
-            exnc = (fun e -> print_string (Printexc.to_string e); dequeue current_qid);
-            effc = fun (type a) (e : a Effect.t) ->
-                   match e with
-                   (* | () -> Atomic.decr num_threads; dequeue current_qid *)
-                   | Suspend f ->
-                      Some (fun (k : (a, _) continuation) ->
-                          begin
-                            match f (k, current_qid) with
-                            | None -> dequeue current_qid
-                            | Some v -> continue k v
-                          end
-                        )
-
-                   | Resume ((t,qid), v) ->
-                      Some (fun (k : (a, _) continuation) ->
-                          if S.is_affine then
-                            begin
-                              enqueue (fun () -> continue t v) qid;
-                              continue k ()
-                            end
-                          else
-                            begin
-                              enqueue (continue k) qid;
-                              continue t v
-                            end
-                        )
-
-                   | Fork f ->
-                      Some (fun (k : (a, _) continuation) ->
-                          if S.is_affine then
-                            begin
-                              enqueue (fun () -> spawn f (fresh_tid ())) current_qid;
-                              continue k ()
-                            end
-                          else
-                            begin
-                              enqueue (continue k) current_qid;
-                              spawn f (fresh_tid ())
-                            end
-                        )
-                   | ForkOn (f, qid) ->
-                      Some (fun (k : (a, _) continuation) ->
-                          if S.is_affine then
-                            begin
-                              enqueue (fun () -> spawn f (fresh_tid ())) qid;
-                              continue k ()
-                            end
-                          else
-                            begin
-                              enqueue (continue k) qid;
-                              spawn f (fresh_tid ())
-                            end
-                        )
-                   | Yield -> Some (fun (k : (a, _) continuation) -> enqueue (continue k) current_qid; dequeue current_qid)
-                   | GetTid -> Some (fun (k : (a, _) continuation) -> continue k tid)
-                   | _ -> None (* forward the unhandled effects to the outer handler *)
-          }
+    Atomic.incr num_threads;
+    (* begin *)
+    match_with f ()
+      {
+        retc =
+          (fun () ->
+            Atomic.decr num_threads;
+            dequeue current_qid);
+        exnc =
+          (fun e ->
+            print_string (Printexc.to_string e);
+            dequeue current_qid);
+        effc =
+          (fun (type a) (e : a Effect.t) ->
+            match e with
+            (* | () -> Atomic.decr num_threads; dequeue current_qid *)
+            | Suspend f ->
+                Some
+                  (fun (k : (a, _) continuation) ->
+                    match f (k, current_qid) with
+                    | None -> dequeue current_qid
+                    | Some v -> continue k v)
+            | Resume ((t, qid), v) ->
+                Some
+                  (fun (k : (a, _) continuation) ->
+                    if S.is_affine then (
+                      enqueue (fun () -> continue t v) qid;
+                      continue k ())
+                    else (
+                      enqueue (continue k) qid;
+                      continue t v))
+            | Fork f ->
+                Some
+                  (fun (k : (a, _) continuation) ->
+                    if S.is_affine then (
+                      enqueue (fun () -> spawn f (fresh_tid ())) current_qid;
+                      continue k ())
+                    else (
+                      enqueue (continue k) current_qid;
+                      spawn f (fresh_tid ())))
+            | ForkOn (f, qid) ->
+                Some
+                  (fun (k : (a, _) continuation) ->
+                    if S.is_affine then (
+                      enqueue (fun () -> spawn f (fresh_tid ())) qid;
+                      continue k ())
+                    else (
+                      enqueue (continue k) qid;
+                      spawn f (fresh_tid ())))
+            | Yield ->
+                Some
+                  (fun (k : (a, _) continuation) ->
+                    enqueue (continue k) current_qid;
+                    dequeue current_qid)
+            | GetTid -> Some (fun (k : (a, _) continuation) -> continue k tid)
+            | _ -> None (* forward the unhandled effects to the outer handler *));
+      }
 
   let run_with f num_domains =
     let started = Atomic.make 0 in
     let worker () =
       let rec loop () =
-        if Atomic.get started = 1 then dequeue (get_qid ())
-        else loop ()
-      in loop ()
+        if Atomic.get started = 1 then dequeue (get_qid ()) else loop ()
+      in
+      loop ()
     in
     add_dom_to_qid_map (Domain.self ());
     for _i = 1 to num_domains - 1 do
       let new_domain = Domain.spawn worker in
-        add_dom_to_qid_map (Domain.get_id new_domain)
+      add_dom_to_qid_map (Domain.get_id new_domain)
     done;
-    spawn (fun () -> Atomic.incr started; f ()) (fresh_tid ())
+    spawn
+      (fun () ->
+        Atomic.incr started;
+        f ())
+      (fresh_tid ())
 
   let run f = run_with f S.num_domains
-
 end

--- a/examples/stack_test.ml
+++ b/examples/stack_test.ml
@@ -17,26 +17,23 @@
 
 let print_usage_and_exit () =
   print_endline @@ "Usage: " ^ Sys.argv.(0) ^ " <num_domains> <num_items>";
-  exit(0)
+  exit 0
 
-let (num_doms, num_items) =
-  if Array.length Sys.argv < 3 then
-    print_usage_and_exit ()
+let num_doms, num_items =
+  if Array.length Sys.argv < 3 then print_usage_and_exit ()
   else
     try
-      let a = int_of_string (Sys.argv.(1)) in
-      let b = int_of_string (Sys.argv.(2)) in
-      (a,b)
-    with
-    | Failure _ -> print_usage_and_exit ()
+      let a = int_of_string Sys.argv.(1) in
+      let b = int_of_string Sys.argv.(2) in
+      (a, b)
+    with Failure _ -> print_usage_and_exit ()
 
 let () =
-  if num_doms mod 2 <> 0 then
-    (print_endline @@ "<num_domains> must be multiple of 2";
-     exit 0)
+  if num_doms mod 2 <> 0 then (
+    print_endline @@ "<num_domains> must be multiple of 2";
+    exit 0)
 
 let items_per_dom = num_items / num_doms
-
 let () = Printf.printf "items_per_domain = %d\n%!" items_per_dom
 
 module M = struct
@@ -45,28 +42,27 @@ module M = struct
 end
 
 module S = Sched_ws.Make (M)
-
 module Reagents = Reagents.Make (S)
 open Reagents
-
 open Printf
 
 module type STACK = sig
   type 'a t
+
   val create : unit -> 'a t
-  val push   : 'a t -> 'a -> unit
-  val pop    : 'a t -> 'a option
+  val push : 'a t -> 'a -> unit
+  val pop : 'a t -> 'a option
 end
 
 module type RSTACK = sig
   type 'a t
-  val create  : unit -> 'a t
-  val push    : 'a t -> ('a, unit) Reagents.t
+
+  val create : unit -> 'a t
+  val push : 'a t -> ('a, unit) Reagents.t
   val try_pop : 'a t -> (unit, 'a option) Reagents.t
 end
 
 module MakeS (RQ : RSTACK) : STACK = struct
-
   type 'a t = 'a RQ.t
 
   let create = RQ.create
@@ -76,8 +72,8 @@ end
 
 module Benchmark = struct
   let get_mean_sd l =
-    let get_mean l = (List.fold_right (fun a v -> a +. v) l 0.) /.
-                (float_of_int @@ List.length l)
+    let get_mean l =
+      List.fold_right (fun a v -> a +. v) l 0. /. (float_of_int @@ List.length l)
     in
     let mean = get_mean l in
     let sd = get_mean @@ List.map (fun v -> abs_float (v -. mean) ** 2.) l in
@@ -85,45 +81,46 @@ module Benchmark = struct
 
   let benchmark f n =
     let rec run acc = function
-    | 0 -> acc
-    | n ->
-        Gc.full_major();
-        let t1 = Unix.gettimeofday () in
-        let () = f () in
-        let d = Unix.gettimeofday () -. t1 in
-        run (d::acc) (n-1)
+      | 0 -> acc
+      | n ->
+          Gc.full_major ();
+          let t1 = Unix.gettimeofday () in
+          let () = f () in
+          let d = Unix.gettimeofday () -. t1 in
+          run (d :: acc) (n - 1)
     in
     let r = run [] n in
     get_mean_sd r
 end
 
 module Sync = Reagents.Sync
-module CDL  = Sync.Countdown_latch
+module CDL = Sync.Countdown_latch
 
 module Test (Q : STACK) = struct
-
   let run num_doms items_per_domain =
     let q : int Q.t = Q.create () in
     let b = CDL.create num_doms in
     (* initialize work *)
     let rec produce = function
       | 0 -> () (* printf "[%d] production complete\n%!" (S.get_qid ()) *)
-      | i -> Q.push q i; produce (i-1)
+      | i ->
+          Q.push q i;
+          produce (i - 1)
     in
     let rec consume i =
       Printf.printf "%d\n%!" i;
       match Q.pop q with
       | None -> print_string @@ sprintf "[%d] consumed=%d\n%!" (S.get_qid ()) i
       | Some _ ->
-          Printf.printf "i+1 = %d\n" (i+1);
-          consume (i+1)
+          Printf.printf "i+1 = %d\n" (i + 1);
+          consume (i + 1)
     in
     for i = 1 to num_doms - 1 do
-      S.fork_on (fun () ->
-        if i mod 2 == 0
-        then produce items_per_domain
-        else consume 0;
-        run (CDL.count_down b) ()) i
+      S.fork_on
+        (fun () ->
+          if i mod 2 == 0 then produce items_per_domain else consume 0;
+          run (CDL.count_down b) ())
+        i
     done;
     produce items_per_domain;
     run (CDL.count_down b) ();
@@ -137,13 +134,14 @@ module Channel_stack : STACK = struct
   module C = Reagents.Channel
   open Reagents
 
-  type 'a t =
-    {stack     : 'a TS.t;
-     elim_push : ('a,unit) C.endpoint;
-     elim_pop  : (unit,'a) C.endpoint}
+  type 'a t = {
+    stack : 'a TS.t;
+    elim_push : ('a, unit) C.endpoint;
+    elim_pop : (unit, 'a) C.endpoint;
+  }
 
   let create () =
-    let (elim_push, elim_pop) = C.mk_chan () in
+    let elim_push, elim_pop = C.mk_chan () in
     { stack = TS.create (); elim_push; elim_pop }
 
   let push q v =
@@ -151,35 +149,39 @@ module Channel_stack : STACK = struct
     Reagents.run r v
 
   let pop q =
-    let side_chan = C.swap q.elim_pop >>= (fun x -> constant (Some x)) in
+    let side_chan = C.swap q.elim_pop >>= fun x -> constant (Some x) in
     let r = side_chan <+> TS.try_pop q.stack in
     Reagents.run r ()
-
 end
 
 let main () =
-  let module M = Test(Lockfree.Michael_scott_queue) in
-  let (m,sd) = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
-  printf "Hand-written Treiber Stack: mean = %f, sd = %f tp=%f\n%!" m sd (float_of_int num_items /. m);
+  let module M = Test (Lockfree.Michael_scott_queue) in
+  let m, sd = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
+  printf "Hand-written Treiber Stack: mean = %f, sd = %f tp=%f\n%!" m sd
+    (float_of_int num_items /. m);
 
-  Gc.full_major();
-  let module M = Test(MakeS(Data.Treiber_stack)) in
-  let (m,sd) = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
-  printf "Treiber stack: mean = %f, sd = %f tp=%f\n%!" m sd (float_of_int num_items /. m);
+  Gc.full_major ();
+  let module M = Test (MakeS (Data.Treiber_stack)) in
+  let m, sd = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
+  printf "Treiber stack: mean = %f, sd = %f tp=%f\n%!" m sd
+    (float_of_int num_items /. m);
 
-  Gc.full_major();
-  let module M = Test(Lock_stack) in
-  let (m,sd) = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
-  printf "Lock stack: mean = %f, sd = %f tp=%f\n%!" m sd (float_of_int num_items /. m);
+  Gc.full_major ();
+  let module M = Test (Lock_stack) in
+  let m, sd = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
+  printf "Lock stack: mean = %f, sd = %f tp=%f\n%!" m sd
+    (float_of_int num_items /. m);
 
-  Gc.full_major();
-  let module M = Test(MakeS(Data.Elimination_stack)) in
-  let (m,sd) = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
-  printf "Elimination stack: mean = %f, sd = %f tp=%f\n%!" m sd (float_of_int num_items /. m);
+  Gc.full_major ();
+  let module M = Test (MakeS (Data.Elimination_stack)) in
+  let m, sd = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
+  printf "Elimination stack: mean = %f, sd = %f tp=%f\n%!" m sd
+    (float_of_int num_items /. m);
 
-  Gc.full_major();
-  let module M = Test(Channel_stack) in
-  let (m,sd) = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
-  printf "Channel-based stack: mean = %f, sd = %f tp=%f\n%!" m sd (float_of_int num_items /. m)
+  Gc.full_major ();
+  let module M = Test (Channel_stack) in
+  let m, sd = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
+  printf "Channel-based stack: mean = %f, sd = %f tp=%f\n%!" m sd
+    (float_of_int num_items /. m)
 
 let () = S.run main

--- a/examples/swap_test.ml
+++ b/examples/swap_test.ml
@@ -15,11 +15,12 @@
  *)
 
 open Printf
-module Scheduler = Sched_ws.Make(
-  struct
-    let num_domains = 1
-    let is_affine = false
-  end)
+
+module Scheduler = Sched_ws.Make (struct
+  let num_domains = 1
+  let is_affine = false
+end)
+
 module Reagents = Reagents.Make (Scheduler)
 open Scheduler
 open Reagents
@@ -32,38 +33,41 @@ let main () =
 
   (* Test 1 *)
   printf "**** Test 1 ****\n%!";
-  let (ep1,ep2) = mk_chan () in
-  let (fp1,fp2) = mk_chan () in
-  fork (fun () -> printf "[%s] %d\n%!" (id_str ()) @@ run (swap fp1 >>> swap ep1) 1);
+  let ep1, ep2 = mk_chan () in
+  let fp1, fp2 = mk_chan () in
+  fork (fun () ->
+      printf "[%s] %d\n%!" (id_str ()) @@ run (swap fp1 >>> swap ep1) 1);
   fork (fun () -> printf "[%s] %d\n%!" (id_str ()) @@ run (swap fp2) 0);
   printf "[%s] %d\n%!" (id_str ()) @@ run (swap ep2) 2;
 
   (* Test 2 *)
   yield ();
-  Unix.sleep (1);
+  Unix.sleep 1;
   printf "**** Test 2 ****\n%!";
-  let (ep1,ep2) = mk_chan () in
-  fork (fun () -> printf "[%s] %d\n%!" (id_str ()) @@ run (swap ep1 >>> swap ep1) 1);
+  let ep1, ep2 = mk_chan () in
+  fork (fun () ->
+      printf "[%s] %d\n%!" (id_str ()) @@ run (swap ep1 >>> swap ep1) 1);
   fork (fun () -> printf "[%s] %d\n%!" (id_str ()) @@ run (swap ep2) 0);
   printf "[%s] %d\n%!" (id_str ()) @@ run (swap ep2) 2;
 
   (* Test 3 *)
   yield ();
-  Unix.sleep (1);
+  Unix.sleep 1;
   printf "**** Test 3 ****\n%!";
-  let (ep1,ep2) = mk_chan () in
+  let ep1, ep2 = mk_chan () in
   fork (fun () ->
-    printf "[%s] %d\n%!" (id_str ()) @@ run (swap ep1 <+> swap ep2) 0);
+      printf "[%s] %d\n%!" (id_str ()) @@ run (swap ep1 <+> swap ep2) 0);
   printf "[%s] %d\n%!" (id_str ()) @@ run (swap ep2) 1;
 
   (* Test 4 *)
   yield ();
-  Unix.sleep (1);
+  Unix.sleep 1;
   printf "**** Test 4 ****\n%!";
-  let (ep1,ep2) = mk_chan () in
+  let ep1, ep2 = mk_chan () in
   fork (fun () ->
-    printf "[%s] %d\n%!" (id_str ()) @@ run (swap ep1 >>> swap ep1) 0);
-  printf "Will fail! Reagents are not as powerful as communicating transactions!\n%!";
+      printf "[%s] %d\n%!" (id_str ()) @@ run (swap ep1 >>> swap ep1) 0);
+  printf
+    "Will fail! Reagents are not as powerful as communicating transactions!\n%!";
   printf "[%s] %d\n%!" (id_str ()) @@ run (swap ep2 >>> swap ep2) 1;
   printf "should not see this!\n";
 

--- a/examples/swap_test2.ml
+++ b/examples/swap_test2.ml
@@ -15,11 +15,12 @@
  *)
 
 open Printf
-module Scheduler = Sched_ws.Make(
-  struct
-    let num_domains = 1
-    let is_affine = false
-  end)
+
+module Scheduler = Sched_ws.Make (struct
+  let num_domains = 1
+  let is_affine = false
+end)
+
 module Reagents = Reagents.Make (Scheduler)
 open Scheduler
 open Reagents
@@ -30,12 +31,9 @@ let id_str () = sprintf "%d:%d" (get_qid ()) (get_tid ())
 
 let main () =
   Printf.printf "This example blocks\n%!";
-  let (a,b) = mk_chan () in
+  let a, b = mk_chan () in
   let r = mk_ref 0 in
-  fork (fun () -> 
-    run (swap a >>> 
-         upd r (fun _ () -> Some (1, ()))) ());
-  run (swap b >>> 
-       upd r (fun _ () -> Some (2, ()))) ()
+  fork (fun () -> run (swap a >>> upd r (fun _ () -> Some (1, ()))) ());
+  run (swap b >>> upd r (fun _ () -> Some (2, ()))) ()
 
 let () = Scheduler.run main

--- a/examples/three_way.ml
+++ b/examples/three_way.ml
@@ -14,27 +14,26 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Scheduler = Sched_ws.Make(
-  struct
-    let num_domains = 1
-    let is_affine = false
-  end)
+module Scheduler = Sched_ws.Make (struct
+  let num_domains = 1
+  let is_affine = false
+end)
+
 module Reagents = Reagents.Make (Scheduler)
 open Scheduler
 open Reagents
 open Reagents.Channel
 
 let mk_tw_chan () =
-  let ab,ba = mk_chan ~name:"ab" () in
-  let bc,cb = mk_chan ~name:"bc" () in
-  let ac,ca = mk_chan ~name:"ac" () in
-  (ab,ac), (ba,bc), (ca,cb)
+  let ab, ba = mk_chan ~name:"ab" () in
+  let bc, cb = mk_chan ~name:"bc" () in
+  let ac, ca = mk_chan ~name:"ac" () in
+  ((ab, ac), (ba, bc), (ca, cb))
 
-let tw_swap (c1, c2) =
-  swap c1 <*> swap c2
+let tw_swap (c1, c2) = swap c1 <*> swap c2
 
 let work sw v () =
-  let (x,y) = run (tw_swap sw) v in
+  let x, y = run (tw_swap sw) v in
   Printf.printf "%d %d" x y
 
 let main () =

--- a/examples/two_way.ml
+++ b/examples/two_way.ml
@@ -14,30 +14,29 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Scheduler = Sched_ws.Make(
-  struct
-    let num_domains = 1
-    let is_affine = false
-  end)
+module Scheduler = Sched_ws.Make (struct
+  let num_domains = 1
+  let is_affine = false
+end)
+
 module Reagents = Reagents.Make (Scheduler)
 open Scheduler
 open Reagents
 open Reagents.Channel
 
 let mk_tw_chan () =
-  let a_p,a_m = mk_chan ~name:"a" () in
-  let b_p,b_m = mk_chan ~name:"b" () in
-  (a_p, b_p), (a_m, b_m)
+  let a_p, a_m = mk_chan ~name:"a" () in
+  let b_p, b_m = mk_chan ~name:"b" () in
+  ((a_p, b_p), (a_m, b_m))
 
-let tw_swap (c1, c2) =
-  swap c1 >>> swap c2
+let tw_swap (c1, c2) = swap c1 >>> swap c2
 
 let work sw v () =
   let x = run (tw_swap sw) v in
   Printf.printf "%d" x
 
 let main () =
-  let sw1, sw2= mk_tw_chan () in
+  let sw1, sw2 = mk_tw_chan () in
   fork (work sw1 1);
   work sw2 2 ()
 

--- a/lib/base.ml
+++ b/lib/base.ml
@@ -16,32 +16,34 @@
 
 module type Scheduler = sig
   type 'a cont
+
   val suspend : ('a cont -> 'a option) -> 'a
-  val resume  : 'a cont -> 'a -> unit
+  val resume : 'a cont -> 'a -> unit
   val get_tid : unit -> int
 end
 
 module type S = sig
-  type ('a,'b) t
-  val never         : ('a,'b) t
-  val constant      : 'a -> ('b,'a) t
-  val post_commit   : ('a -> unit) -> ('a, 'a) t
-  val lift          : ('a -> 'b) -> ('a,'b) t
-  val lift_blocking : ('a -> 'b option) -> ('a,'b) t
-  val return        : ('a -> (unit, 'b) t) -> ('a,'b) t
-  val (>>=)         : ('a,'b) t -> ('b -> (unit,'c) t) -> ('a,'c) t
-  val (>>>)         : ('a,'b) t -> ('b,'c) t -> ('a,'c) t
-  val (<+>)         : ('a,'b) t -> ('a,'b) t -> ('a,'b) t
-  val (<*>)         : ('a,'b) t -> ('a,'c) t -> ('a, 'b * 'c) t
-  val attempt       : ('a,'b) t -> ('a, 'b option) t
-  val run           : ('a,'b) t -> 'a -> 'b
+  type ('a, 'b) t
 
-  module Ref : Ref.S with type ('a,'b) reagent = ('a,'b) t
-  module Channel : Channel.S with type ('a,'b) reagent = ('a,'b) t
+  val never : ('a, 'b) t
+  val constant : 'a -> ('b, 'a) t
+  val post_commit : ('a -> unit) -> ('a, 'a) t
+  val lift : ('a -> 'b) -> ('a, 'b) t
+  val lift_blocking : ('a -> 'b option) -> ('a, 'b) t
+  val return : ('a -> (unit, 'b) t) -> ('a, 'b) t
+  val ( >>= ) : ('a, 'b) t -> ('b -> (unit, 'c) t) -> ('a, 'c) t
+  val ( >>> ) : ('a, 'b) t -> ('b, 'c) t -> ('a, 'c) t
+  val ( <+> ) : ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t
+  val ( <*> ) : ('a, 'b) t -> ('a, 'c) t -> ('a, 'b * 'c) t
+  val attempt : ('a, 'b) t -> ('a, 'b option) t
+  val run : ('a, 'b) t -> 'a -> 'b
+
+  module Ref : Ref.S with type ('a, 'b) reagent = ('a, 'b) t
+  module Channel : Channel.S with type ('a, 'b) reagent = ('a, 'b) t
 end
 
-module Make (Sched: Scheduler) : S = struct
-  include Core.Make(Sched)
-  module Ref = Ref.Make(Sched)
-  module Channel = Channel.Make(Sched)
+module Make (Sched : Scheduler) : S = struct
+  include Core.Make (Sched)
+  module Ref = Ref.Make (Sched)
+  module Channel = Channel.Make (Sched)
 end

--- a/lib/base.mli
+++ b/lib/base.mli
@@ -14,7 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-
 module type Scheduler = sig
   type 'a cont
   (** The type of continuation. *)
@@ -25,7 +24,7 @@ module type Scheduler = sig
       returns [None], then the current fiber is suspended and the control
       switches to the next fiber from the scheduler. *)
 
-  val resume  : 'a cont -> 'a -> unit
+  val resume : 'a cont -> 'a -> unit
   (** [resume k v] prepares to resume the continuation [k] with value [v] and
       enqueues the continuation to the scheduler queue. *)
 
@@ -34,61 +33,60 @@ module type Scheduler = sig
 end
 
 module type S = sig
-
-  type ('a,'b) t
+  type ('a, 'b) t
   (** The type of a reagent computation which accepts a value of type ['a] and
       returns a value of type ['b]. *)
 
-  val never : ('a,'b) t
+  val never : ('a, 'b) t
   (** A reagent that is never enabled. *)
 
-  val constant : 'a -> ('b,'a) t
+  val constant : 'a -> ('b, 'a) t
   (** [constant v] is a reagent that always returns [v]. *)
 
   val post_commit : ('a -> unit) -> ('a, 'a) t
   (** [post_commit f] returns a reagent [r] that runs [f r] after the reagent
       [r] (or any reagent constructed using [r]) commits. *)
 
-  val lift : ('a -> 'b) -> ('a,'b) t
+  val lift : ('a -> 'b) -> ('a, 'b) t
   (** [lift f] lifts a pure function [f] to a reagent. If [f] includes
       side-effects, then the side-effects may be performed zero or more times.
       It is expected that [f] does not perform any blocking operations. *)
 
-  val lift_blocking : ('a -> 'b option) -> ('a,'b) t
+  val lift_blocking : ('a -> 'b option) -> ('a, 'b) t
   (** [lift_blocking f] blocks if [f] returns [None]. Otherwise, it behaves
       like {!lift}. *)
 
-  val return : ('a -> (unit, 'b) t) -> ('a,'b) t
+  val return : ('a -> (unit, 'b) t) -> ('a, 'b) t
   (** The monadic return primitive for reagents. *)
 
-  val (>>=) : ('a,'b) t -> ('b -> (unit,'c) t) -> ('a,'c) t
+  val ( >>= ) : ('a, 'b) t -> ('b -> (unit, 'c) t) -> ('a, 'c) t
   (** The monadic bind primitive for reagents. *)
 
-  val (>>>) : ('a,'b) t -> ('b,'c) t -> ('a,'c) t
+  val ( >>> ) : ('a, 'b) t -> ('b, 'c) t -> ('a, 'c) t
   (** The sequential composition operator. [a >>> b] perform [a] and [b]
       atomically. Corresponds to arrow bind. *)
 
-  val (<+>) : ('a,'b) t -> ('a,'b) t -> ('a,'b) t
+  val ( <+> ) : ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t
   (** Left-biased choice. [a <+> b] first attempts [a]. If [a] blocks, then [b]
       is attempted. If both of them block, then the whole protocol blocks. *)
 
-  val (<*>) : ('a,'b) t -> ('a,'c) t -> ('a, 'b * 'c) t
+  val ( <*> ) : ('a, 'b) t -> ('a, 'c) t -> ('a, 'b * 'c) t
   (** Parallel composition operator. [a <*> b] is only enabled if both [a] and
       [b] are enabled. *)
 
-  val attempt : ('a,'b) t -> ('a, 'b option) t
+  val attempt : ('a, 'b) t -> ('a, 'b option) t
   (** Convert a blocking reagent into a non-blocking one. If reagent [r] is a
       blocks, then [attempt r] return [None]. If [r] does not block and returns
       a value [v], then [attempt r] returns [Some v]. *)
 
-  val run : ('a,'b) t -> 'a -> 'b
+  val run : ('a, 'b) t -> 'a -> 'b
   (** [run r v] runs the reagents [r] with value [v]. *)
 
-  module Ref : Ref.S with type ('a,'b) reagent = ('a,'b) t
+  module Ref : Ref.S with type ('a, 'b) reagent = ('a, 'b) t
   (** Shared memory references. *)
 
-  module Channel : Channel.S with type ('a,'b) reagent = ('a,'b) t
+  module Channel : Channel.S with type ('a, 'b) reagent = ('a, 'b) t
   (** Synchronous message-passing channels. *)
 end
 
-module Make (Sched: Scheduler) : S
+module Make (Sched : Scheduler) : S

--- a/lib/channel.ml
+++ b/lib/channel.ml
@@ -16,115 +16,118 @@
  *)
 
 module type S = sig
-  type ('a,'b) endpoint
-  type ('a,'b) reagent
+  type ('a, 'b) endpoint
+  type ('a, 'b) reagent
 
-  val mk_chan : ?name:string -> unit -> ('a,'b) endpoint * ('b,'a) endpoint
-  val swap    : ('a,'b) endpoint -> ('a,'b) reagent
+  val mk_chan : ?name:string -> unit -> ('a, 'b) endpoint * ('b, 'a) endpoint
+  val swap : ('a, 'b) endpoint -> ('a, 'b) reagent
 end
 
-module Make (Sched : Scheduler.S) : S with
-  type ('a,'b) reagent = ('a,'b) Core.Make(Sched).t = struct
-
-  module Core = Core.Make(Sched)
-  module Reaction = Reaction.Make(Sched)
-  module Offer = Offer.Make(Sched)
-
+module Make (Sched : Scheduler.S) :
+  S with type ('a, 'b) reagent = ('a, 'b) Core.Make(Sched).t = struct
+  module Core = Core.Make (Sched)
+  module Reaction = Reaction.Make (Sched)
+  module Offer = Offer.Make (Sched)
   open Core
 
-  type ('a,'b) reagent = ('a,'b) Core.t
+  type ('a, 'b) reagent = ('a, 'b) Core.t
 
-  type ('a,'b) message =
-    Message : 'c Offer.t * ('b,'a) t -> ('a,'b) message
+  type ('a, 'b) message =
+    | Message : 'c Offer.t * ('b, 'a) t -> ('a, 'b) message
 
-  let mk_message (type a) (type b) (type c) (payload : a) (sender_rx : Reaction.t)
-                 (sender_k : (b,c) t) (sender_offer : c Offer.t) =
-    let try_react payload sender_offer sender_rx receiver_k c receiver_rx receiver_offer =
+  let mk_message (type a b c) (payload : a) (sender_rx : Reaction.t)
+      (sender_k : (b, c) t) (sender_offer : c Offer.t) =
+    let try_react payload sender_offer sender_rx receiver_k c receiver_rx
+        receiver_offer =
       let rx = Reaction.union sender_rx receiver_rx in
       let cas = Offer.complete sender_offer c in
       let new_rx =
-        if can_cas_immediate receiver_k rx receiver_offer then
+        if can_cas_immediate receiver_k rx receiver_offer then (
           match PostCommitCas.commit cas with
           | None -> None
-          | Some f -> ( f (); Some rx )
+          | Some f ->
+              f ();
+              Some rx)
         else Some (Reaction.with_CAS rx cas)
       in
       match new_rx with
       | None -> Retry
       | Some new_rx -> receiver_k.try_react payload new_rx receiver_offer
     in
-    let rec complete_exchange : 'd. (a,'d) t -> (c,'d) t =
-      fun receiver_k ->
-        { always_commits = false;
-          compose = (fun next -> complete_exchange (receiver_k.compose next));
-          try_react = try_react payload sender_offer sender_rx receiver_k}
+    let rec complete_exchange : 'd. (a, 'd) t -> (c, 'd) t =
+     fun receiver_k ->
+      {
+        always_commits = false;
+        compose = (fun next -> complete_exchange (receiver_k.compose next));
+        try_react = try_react payload sender_offer sender_rx receiver_k;
+      }
     in
-    let complete_exchange =
-          sender_k.compose (complete_exchange Core.commit)
-    in
+    let complete_exchange = sender_k.compose (complete_exchange Core.commit) in
     Message (sender_offer, complete_exchange)
 
-  type ('a,'b) endpoint =
-    { name : string;
-      outgoing: ('a,'b) message Lockfree.Michael_scott_queue.t;
-      incoming: ('b,'a) message Lockfree.Michael_scott_queue.t }
+  type ('a, 'b) endpoint = {
+    name : string;
+    outgoing : ('a, 'b) message Lockfree.Michael_scott_queue.t;
+    incoming : ('b, 'a) message Lockfree.Michael_scott_queue.t;
+  }
 
   let mk_chan ?name () =
-    let name =
-      match name with
-      | None -> ""
-      | Some n -> n
-    in
+    let name = match name with None -> "" | Some n -> n in
     let l1 = Lockfree.Michael_scott_queue.create () in
     let l2 = Lockfree.Michael_scott_queue.create () in
-    {name = "+" ^ name; incoming = l1; outgoing = l2},
-    {name = "-" ^ name; incoming = l2; outgoing = l1}
+    ( { name = "+" ^ name; incoming = l1; outgoing = l2 },
+      { name = "-" ^ name; incoming = l2; outgoing = l1 } )
 
-  let message_is_active (Message (o,_)) = Offer.is_active o
+  let message_is_active (Message (o, _)) = Offer.is_active o
 
-  let rec swap : 'a 'b 'r. ('a,'b) endpoint -> ('b,'r) reagent -> ('a,'r) reagent =
+  let rec swap :
+            'a 'b 'r. ('a, 'b) endpoint -> ('b, 'r) reagent -> ('a, 'r) reagent
+      =
     let try_react ep k a rx offer =
-      let {name = _name; outgoing; incoming} = ep in
+      let { name = _name; outgoing; incoming } = ep in
       (* Search for matching offers *)
       let rec try_from cursor retry =
         match Lockfree.Michael_scott_queue.next cursor with
         | None -> if retry then Retry else Block
-        | Some (Message (sender_offer,exchange), cursor) ->
+        | Some (Message (sender_offer, exchange), cursor) -> (
             let same_offer o = function
-            | None -> false
-            | Some o' -> Offer.equal o o'
+              | None -> false
+              | Some o' -> Offer.equal o o'
             in
-            ( if (not (Offer.is_active sender_offer))
-                || Reaction.has_offer rx sender_offer
-                || same_offer sender_offer offer then
-(*                   let _ = Printf.printf "me!!\n" in *)
-                  try_from cursor retry
-              else (* Found matching offer *)
-(*                 let _ = Printf.printf "found matching offer!\n" in *)
-                let new_rx = Reaction.with_offer rx sender_offer in
-                let merged = exchange.compose k in
-                match merged.try_react a new_rx offer with
-                | Retry -> try_from cursor true
-                | Block | BlockAndRetry -> try_from cursor retry
-                | v -> v )
+            if
+              (not (Offer.is_active sender_offer))
+              || Reaction.has_offer rx sender_offer
+              || same_offer sender_offer offer
+            then
+              (*                   let _ = Printf.printf "me!!\n" in *)
+              try_from cursor retry
+            else
+              (* Found matching offer *)
+              (*                 let _ = Printf.printf "found matching offer!\n" in *)
+              let new_rx = Reaction.with_offer rx sender_offer in
+              let merged = exchange.compose k in
+              match merged.try_react a new_rx offer with
+              | Retry -> try_from cursor true
+              | Block | BlockAndRetry -> try_from cursor retry
+              | v -> v)
       in
-      ( begin
-          match offer with
-          | Some offer (* when (not k.may_sync) *) ->
-(*               Printf.printf "[%d,%s] pushing offer %d\n"  *)
-(*                 (Sched.get_tid ()) name @@ Offer.get_id offer; *)
-             Lockfree.Michael_scott_queue.push outgoing (mk_message a rx k offer)
-          | _ -> ()
-        end;
-(*         Printf.printf "[%d,%s] checking..\n" (Sched.get_tid()) name; *)
-        Lockfree.Michael_scott_queue.clean_until incoming message_is_active;
-        if Lockfree.Michael_scott_queue.is_empty incoming then Block
-        else try_from (Lockfree.Michael_scott_queue.snapshot incoming) false )
+      (match offer with
+      | Some offer (* when (not k.may_sync) *) ->
+          (*               Printf.printf "[%d,%s] pushing offer %d\n"  *)
+          (*                 (Sched.get_tid ()) name @@ Offer.get_id offer; *)
+          Lockfree.Michael_scott_queue.push outgoing (mk_message a rx k offer)
+      | _ -> ());
+      (*         Printf.printf "[%d,%s] checking..\n" (Sched.get_tid()) name; *)
+      Lockfree.Michael_scott_queue.clean_until incoming message_is_active;
+      if Lockfree.Michael_scott_queue.is_empty incoming then Block
+      else try_from (Lockfree.Michael_scott_queue.snapshot incoming) false
     in
     fun ep k ->
-      { always_commits = false;
+      {
+        always_commits = false;
         compose = (fun next -> swap ep (k.compose next));
-        try_react = try_react ep k}
+        try_react = try_react ep k;
+      }
 
   let swap ep = swap ep Core.commit
 end

--- a/lib/channel.mli
+++ b/lib/channel.mli
@@ -16,20 +16,19 @@
  *)
 
 module type S = sig
-  type ('a,'b) endpoint
+  type ('a, 'b) endpoint
   (** The type of endpoint which accepts value of type ['a] and return value of
       type ['b]. *)
 
-  type ('a,'b) reagent
+  type ('a, 'b) reagent
   (** The type of reagent. See {!Reagents.S.t}. *)
 
-  val mk_chan : ?name:string -> unit -> ('a,'b) endpoint * ('b,'a) endpoint
+  val mk_chan : ?name:string -> unit -> ('a, 'b) endpoint * ('b, 'a) endpoint
   (** Make a new channel. Returns a pair of dual endpoints. *)
 
-  val swap : ('a,'b) endpoint -> ('a,'b) reagent
+  val swap : ('a, 'b) endpoint -> ('a, 'b) reagent
   (** Swap on the channel. *)
-
 end
 
-module Make (Sched : Scheduler.S) : S with
-  type ('a,'b) reagent = ('a,'b) Core.Make(Sched).t
+module Make (Sched : Scheduler.S) :
+  S with type ('a, 'b) reagent = ('a, 'b) Core.Make(Sched).t

--- a/lib/condition_variable.ml
+++ b/lib/condition_variable.ml
@@ -1,26 +1,25 @@
 module type S = sig
-  type ('a,'b) reagent
+  type ('a, 'b) reagent
   type lock
   type t
 
   val create : unit -> t
   (** [wait l c] returns [false] if the lock is not currently held. *)
 
-  val wait      : lock -> t -> bool
-  val signal    : t -> unit
+  val wait : lock -> t -> bool
+  val signal : t -> unit
   val broadcast : t -> unit
 end
 
-module Make (Base: Base.S) (Lock : Lock.S with type ('a,'b) reagent = ('a,'b) Base.t) : S
-  with type ('a,'b) reagent = ('a,'b) Base.t
-   and type lock = Lock.t = struct
-
-  type ('a,'b) reagent = ('a,'b) Base.t
+module Make
+    (Base : Base.S)
+    (Lock : Lock.S with type ('a, 'b) reagent = ('a, 'b) Base.t) :
+  S with type ('a, 'b) reagent = ('a, 'b) Base.t and type lock = Lock.t = struct
+  type ('a, 'b) reagent = ('a, 'b) Base.t
 
   open Base
-
-  module Q = MichaelScott_queue.Make(Base)
-  module X = Exchanger.Make(Base)
+  module Q = MichaelScott_queue.Make (Base)
+  module X = Exchanger.Make (Base)
 
   type lock = Lock.t
   type t = unit X.t Q.t
@@ -30,22 +29,22 @@ module Make (Base: Base.S) (Lock : Lock.S with type ('a,'b) reagent = ('a,'b) Ba
   let wait l cv =
     let x = X.create () in
     run (constant x >>> Q.push cv) ();
-    if run (Lock.rel l) () then
+    if run (Lock.rel l) () then (
       (* Successfully released lock. Wait for signal.. *)
-      ( run (X.exchange x) ();
-        run (Lock.acq l) ();
-        true)
-    else
-      (* Error! Lock not owned. TODO: Remove/satisfy x.*)
+      run (X.exchange x) ();
+      run (Lock.acq l) ();
+      true)
+    else (* Error! Lock not owned. TODO: Remove/satisfy x.*)
       false
 
   let signal_bool cv =
     let xo = run (Q.try_pop cv) () in
     match xo with
     | None -> false
-    | Some x -> ( run (X.exchange x) (); true )
+    | Some x ->
+        run (X.exchange x) ();
+        true
 
   let signal cv = ignore (signal_bool cv)
-
   let rec broadcast cv = if signal_bool cv then broadcast cv else ()
 end

--- a/lib/condition_variable.mli
+++ b/lib/condition_variable.mli
@@ -1,17 +1,18 @@
 module type S = sig
-  type ('a,'b) reagent
+  type ('a, 'b) reagent
   type lock
   type t
 
   val create : unit -> t
 
-  val wait      : lock -> t -> bool
+  val wait : lock -> t -> bool
   (** [wait l c] returns [false] if the lock is not currently held. *)
 
-  val signal    : t -> unit
+  val signal : t -> unit
   val broadcast : t -> unit
 end
 
-module Make (Base: Base.S) (Lock : Lock.S with type ('a,'b) reagent = ('a,'b) Base.t) : S
-  with type ('a,'b) reagent = ('a,'b) Base.t
-   and type lock = Lock.t
+module Make
+    (Base : Base.S)
+    (Lock : Lock.S with type ('a, 'b) reagent = ('a, 'b) Base.t) :
+  S with type ('a, 'b) reagent = ('a, 'b) Base.t and type lock = Lock.t

--- a/lib/core.ml
+++ b/lib/core.ml
@@ -19,190 +19,192 @@ module type S = sig
   type reaction
   type 'a offer
   type 'a result = BlockAndRetry | Block | Retry | Done of 'a
-  type ('a,'b) t =
-    { try_react : 'a -> reaction -> 'b offer option -> 'b result;
-      compose : 'r. ('b,'r) t -> ('a,'r) t;
-      always_commits : bool }
 
-  val never         : ('a,'b) t
-  val constant      : 'a -> ('b,'a) t
-  val post_commit   : ('a -> unit) -> ('a, 'a) t
-  val lift          : ('a -> 'b) -> ('a,'b) t
+  type ('a, 'b) t = {
+    try_react : 'a -> reaction -> 'b offer option -> 'b result;
+    compose : 'r. ('b, 'r) t -> ('a, 'r) t;
+    always_commits : bool;
+  }
+
+  val never : ('a, 'b) t
+  val constant : 'a -> ('b, 'a) t
+  val post_commit : ('a -> unit) -> ('a, 'a) t
+  val lift : ('a -> 'b) -> ('a, 'b) t
   val lift_blocking : ('a -> 'b option) -> ('a, 'b) t
-  val return        : ('a -> (unit, 'b) t) -> ('a,'b) t
-  val (>>=)         : ('a,'b) t -> ('b -> (unit,'c) t) -> ('a,'c) t
-  val (>>>)         : ('a,'b) t -> ('b,'c) t -> ('a,'c) t
-  val (<+>)         : ('a,'b) t -> ('a,'b) t -> ('a,'b) t
-  val (<*>)         : ('a,'b) t -> ('a,'c) t -> ('a, 'b * 'c) t
-  val attempt       : ('a,'b) t -> ('a, 'b option) t
-  val run           : ('a,'b) t -> 'a -> 'b
-
-  val commit : ('a,'a) t
-  val can_cas_immediate : ('a,'b) t -> reaction -> 'c offer option -> bool
+  val return : ('a -> (unit, 'b) t) -> ('a, 'b) t
+  val ( >>= ) : ('a, 'b) t -> ('b -> (unit, 'c) t) -> ('a, 'c) t
+  val ( >>> ) : ('a, 'b) t -> ('b, 'c) t -> ('a, 'c) t
+  val ( <+> ) : ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t
+  val ( <*> ) : ('a, 'b) t -> ('a, 'c) t -> ('a, 'b * 'c) t
+  val attempt : ('a, 'b) t -> ('a, 'b option) t
+  val run : ('a, 'b) t -> 'a -> 'b
+  val commit : ('a, 'a) t
+  val can_cas_immediate : ('a, 'b) t -> reaction -> 'c offer option -> bool
 end
 
-module Make (Sched: Scheduler.S) : S
-  with type reaction = Reaction.Make(Sched).t
-   and type 'a offer = 'a Offer.Make(Sched).t = struct
-
-  module Reaction = Reaction.Make(Sched)
-  module Offer = Offer.Make(Sched)
+module Make (Sched : Scheduler.S) :
+  S
+    with type reaction = Reaction.Make(Sched).t
+     and type 'a offer = 'a Offer.Make(Sched).t = struct
+  module Reaction = Reaction.Make (Sched)
+  module Offer = Offer.Make (Sched)
 
   type reaction = Reaction.t
   type 'a offer = 'a Offer.t
-
   type 'a result = BlockAndRetry | Block | Retry | Done of 'a
 
-  type ('a,'b) t =
-    { try_react : 'a -> Reaction.t -> 'b Offer.t option -> 'b result;
-      compose : 'r. ('b,'r) t -> ('a,'r) t;
-      always_commits : bool }
+  type ('a, 'b) t = {
+    try_react : 'a -> Reaction.t -> 'b Offer.t option -> 'b result;
+    compose : 'r. ('b, 'r) t -> ('a, 'r) t;
+    always_commits : bool;
+  }
 
+  let ( >>> ) r1 r2 = r1.compose r2
 
-  let (>>>) r1 r2 = r1.compose r2
-
-  let rec never : 'a 'b. ('a,'b) t =
-    { try_react = (fun _ _ _ -> Block);
+  let rec never : 'a 'b. ('a, 'b) t =
+    {
+      try_react = (fun _ _ _ -> Block);
       always_commits = false;
-      compose = fun _ -> never }
+      compose = (fun _ -> never);
+    }
 
-  let commit : ('a,'a) t =
+  let commit : ('a, 'a) t =
     let try_react a rx = function
-      | None -> (* No offer *)
+      | None ->
+          (* No offer *)
           if Reaction.try_commit rx then Done a else Retry
-      | Some offer ->
+      | Some offer -> (
           match Offer.rescind offer with
-          | None -> (* Offer rescinded successfully *)
+          | None ->
+              (* Offer rescinded successfully *)
               if Reaction.try_commit rx then Done a else Retry
-          | Some a' -> Done a'
+          | Some a' -> Done a')
     in
-    { always_commits = true;
-      compose = (fun next -> next);
-      try_react }
+    { always_commits = true; compose = (fun next -> next); try_react }
 
-  type ('a,'b) mkr_info =
-    { ret_val : 'a -> 'b result;
-      new_rx  : 'a -> Reaction.t -> Reaction.t }
+  type ('a, 'b) mkr_info = {
+    ret_val : 'a -> 'b result;
+    new_rx : 'a -> Reaction.t -> Reaction.t;
+  }
 
-  let rec mk_reagent : 'a 'b 'r. ('a,'b) mkr_info -> ('b,'r) t -> ('a,'r) t =
-    fun m k ->
-      { always_commits = k.always_commits;
-        try_react = (fun a rx o ->
+  let rec mk_reagent : 'a 'b 'r. ('a, 'b) mkr_info -> ('b, 'r) t -> ('a, 'r) t =
+   fun m k ->
+    {
+      always_commits = k.always_commits;
+      try_react =
+        (fun a rx o ->
           match m.ret_val a with
           | Done b -> k.try_react b (m.new_rx a rx) o
           | Retry -> Retry
           | Block -> Block
           | BlockAndRetry -> BlockAndRetry);
-        compose = (fun next -> mk_reagent m (k.compose next)) }
+      compose = (fun next -> mk_reagent m (k.compose next));
+    }
 
-  let constant (x : 'a) : ('b,'a) t =
-    mk_reagent {ret_val = (fun _ -> Done x); new_rx = (fun _ v -> v)} commit
+  let constant (x : 'a) : ('b, 'a) t =
+    mk_reagent { ret_val = (fun _ -> Done x); new_rx = (fun _ v -> v) } commit
 
-  let post_commit (f : 'a -> unit) : ('a,'a) t =
+  let post_commit (f : 'a -> unit) : ('a, 'a) t =
     let ret_val v = Done v in
     let new_rx v rx = Reaction.with_post_commit rx (fun () -> f v) in
-    mk_reagent {ret_val; new_rx} commit
+    mk_reagent { ret_val; new_rx } commit
 
-  let lift (f : 'a -> 'b) : ('a,'b) t =
+  let lift (f : 'a -> 'b) : ('a, 'b) t =
     let ret_val v = Done (f v) in
-    mk_reagent {ret_val; new_rx = (fun _ v -> v)} commit
+    mk_reagent { ret_val; new_rx = (fun _ v -> v) } commit
 
   (* [f] should be a pure function *)
-  let lift_blocking (f : 'a -> 'b option) : ('a,'b) t =
-    let ret_val v =
-      match f v with
-      | None -> Block
-      | Some r -> Done r
-    in
-    mk_reagent {ret_val; new_rx = (fun _ v -> v)} commit
+  let lift_blocking (f : 'a -> 'b option) : ('a, 'b) t =
+    let ret_val v = match f v with None -> Block | Some r -> Done r in
+    mk_reagent { ret_val; new_rx = (fun _ v -> v) } commit
 
   let rec return : 'a 'b 'r. ('a -> (unit, 'b) t) -> ('b, 'r) t -> ('a, 'r) t =
-    fun f k ->
-      { always_commits = false;
-        compose = (fun next -> return f (k.compose next));
-        try_react = (fun a rx o -> ((f a).compose k).try_react () rx o) }
+   fun f k ->
+    {
+      always_commits = false;
+      compose = (fun next -> return f (k.compose next));
+      try_react = (fun a rx o -> ((f a).compose k).try_react () rx o);
+    }
 
   let return f = return f commit
+  let ( >>= ) r f = r >>> return f
 
-  let (>>=) r f = r >>> (return f)
-
-  let rec (<+>) : 'a 'b 'r. ('a,'b) t -> ('a,'b) t -> ('a,'b) t =
-    fun r1 r2 ->
-      { always_commits = r1.always_commits && r2.always_commits;
-        compose = (fun next -> r1.compose next <+> r2.compose next);
-        try_react = fun a rx offer ->
+  let rec ( <+> ) : 'a 'b 'r. ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t =
+   fun r1 r2 ->
+    {
+      always_commits = r1.always_commits && r2.always_commits;
+      compose = (fun next -> r1.compose next <+> r2.compose next);
+      try_react =
+        (fun a rx offer ->
           match r1.try_react a rx offer with
-          | (Done _) as v -> v
-          | Block ->
-              begin
-                match r2.try_react a rx offer with
-                | Retry -> BlockAndRetry
-                | v -> v
-              end
-          | Retry ->
-              begin
-                match r2.try_react a rx offer with
-                | Block -> BlockAndRetry
-                | v -> v
-              end
-          | BlockAndRetry ->
-              begin
-                match r2.try_react a rx offer with
-                | Retry | Block -> BlockAndRetry
-                | v -> v
-              end}
+          | Done _ as v -> v
+          | Block -> (
+              match r2.try_react a rx offer with
+              | Retry -> BlockAndRetry
+              | v -> v)
+          | Retry -> (
+              match r2.try_react a rx offer with
+              | Block -> BlockAndRetry
+              | v -> v)
+          | BlockAndRetry -> (
+              match r2.try_react a rx offer with
+              | Retry | Block -> BlockAndRetry
+              | v -> v));
+    }
 
-  let attempt (r : ('a,'b) t) : ('a,'b option) t =
-    (<+>) (r >>> lift (fun x -> (Some x))) (constant None)
+  let attempt (r : ('a, 'b) t) : ('a, 'b option) t =
+    r >>> lift (fun x -> Some x) <+> constant None
 
-  let rec first : 'a 'b 'c 'r. ('a,'b) t -> ('b * 'c,'r) t -> ('a * 'c, 'r) t =
-    fun r k ->
-      let try_react (a,c) rx offer =
-        (r >>> lift (fun b -> (b, c)) >>> k).try_react a rx offer
-      in
-      { always_commits = r.always_commits && k.always_commits;
-        compose = (fun next -> first r (k.compose next));
-        try_react }
+  let rec first : 'a 'b 'c 'r. ('a, 'b) t -> ('b * 'c, 'r) t -> ('a * 'c, 'r) t
+      =
+   fun r k ->
+    let try_react (a, c) rx offer =
+      (r >>> lift (fun b -> (b, c)) >>> k).try_react a rx offer
+    in
+    {
+      always_commits = r.always_commits && k.always_commits;
+      compose = (fun next -> first r (k.compose next));
+      try_react;
+    }
 
-  let first (r : ('a,'b) t) : ('a * 'c, 'b * 'c) t = first r commit
+  let first (r : ('a, 'b) t) : ('a * 'c, 'b * 'c) t = first r commit
 
-  let rec second : 'a 'b 'c 'r. ('a,'b) t -> ('c * 'b,'r) t -> ('c * 'a, 'r) t =
-    fun r k ->
-      let try_react (c,a) rx offer =
-        (r >>> lift (fun b -> (c, b)) >>> k).try_react a rx offer
-      in
-      { always_commits = r.always_commits && k.always_commits;
-        compose = (fun next -> second r (k.compose next));
-        try_react }
+  let rec second : 'a 'b 'c 'r. ('a, 'b) t -> ('c * 'b, 'r) t -> ('c * 'a, 'r) t
+      =
+   fun r k ->
+    let try_react (c, a) rx offer =
+      (r >>> lift (fun b -> (c, b)) >>> k).try_react a rx offer
+    in
+    {
+      always_commits = r.always_commits && k.always_commits;
+      compose = (fun next -> second r (k.compose next));
+      try_react;
+    }
 
-  let second (r : ('a,'b) t) : ('c * 'a, 'c * 'b) t = second r commit
+  let second (r : ('a, 'b) t) : ('c * 'a, 'c * 'b) t = second r commit
 
-  let (<*>) (r1 : ('a,'b) t) (r2 : ('a,'c) t) : ('a,'b*'c) t =
-    lift (fun a -> (a,a)) >>> first (r1) >>> second (r2)
+  let ( <*> ) (r1 : ('a, 'b) t) (r2 : ('a, 'c) t) : ('a, 'b * 'c) t =
+    lift (fun a -> (a, a)) >>> first r1 >>> second r2
 
   let rec with_offer pause r v =
     let offer = Offer.make () in
     match r.try_react v Reaction.empty (Some offer) with
     | Done res -> res
-    | f ->
-      ( begin
-          match f with
-          | Block -> Offer.wait offer
-          | _ -> pause ()
-        end;
+    | f -> (
+        (match f with Block -> Offer.wait offer | _ -> pause ());
         match Offer.rescind offer with
         | Some ans -> ans
-        | None -> with_offer pause r v )
+        | None -> with_offer pause r v)
 
   let rec without_offer pause r v =
     match r.try_react v Reaction.empty None with
     | Done res -> res
     | Retry ->
-          ( pause ();
-            without_offer pause r v )
+        pause ();
+        without_offer pause r v
     | BlockAndRetry ->
-          ( pause ();
-            with_offer pause r v )
+        pause ();
+        with_offer pause r v
     | Block -> with_offer pause r v
 
   let run r v =

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -16,32 +16,33 @@
  *)
 
 module type S = sig
-
   type reaction
   type 'a offer
   type 'a result = BlockAndRetry | Block | Retry | Done of 'a
-  type ('a,'b) t =
-    { try_react : 'a -> reaction -> 'b offer option -> 'b result;
-      compose : 'r. ('b,'r) t -> ('a,'r) t;
-      always_commits : bool }
 
-  val never         : ('a,'b) t
-  val constant      : 'a -> ('b,'a) t
-  val post_commit   : ('a -> unit) -> ('a, 'a) t
-  val lift          : ('a -> 'b) -> ('a,'b) t
-  val lift_blocking : ('a -> 'b option) -> ('a,'b) t
-  val return        : ('a -> (unit, 'b) t) -> ('a,'b) t
-  val (>>=)         : ('a,'b) t -> ('b -> (unit,'c) t) -> ('a,'c) t
-  val (>>>)         : ('a,'b) t -> ('b,'c) t -> ('a,'c) t
-  val (<+>)         : ('a,'b) t -> ('a,'b) t -> ('a,'b) t
-  val (<*>)         : ('a,'b) t -> ('a,'c) t -> ('a, 'b * 'c) t
-  val attempt       : ('a,'b) t -> ('a, 'b option) t
-  val run           : ('a,'b) t -> 'a -> 'b
+  type ('a, 'b) t = {
+    try_react : 'a -> reaction -> 'b offer option -> 'b result;
+    compose : 'r. ('b, 'r) t -> ('a, 'r) t;
+    always_commits : bool;
+  }
 
-  val commit : ('a,'a) t
-  val can_cas_immediate : ('a,'b) t -> reaction -> 'c offer option -> bool
+  val never : ('a, 'b) t
+  val constant : 'a -> ('b, 'a) t
+  val post_commit : ('a -> unit) -> ('a, 'a) t
+  val lift : ('a -> 'b) -> ('a, 'b) t
+  val lift_blocking : ('a -> 'b option) -> ('a, 'b) t
+  val return : ('a -> (unit, 'b) t) -> ('a, 'b) t
+  val ( >>= ) : ('a, 'b) t -> ('b -> (unit, 'c) t) -> ('a, 'c) t
+  val ( >>> ) : ('a, 'b) t -> ('b, 'c) t -> ('a, 'c) t
+  val ( <+> ) : ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t
+  val ( <*> ) : ('a, 'b) t -> ('a, 'c) t -> ('a, 'b * 'c) t
+  val attempt : ('a, 'b) t -> ('a, 'b option) t
+  val run : ('a, 'b) t -> 'a -> 'b
+  val commit : ('a, 'a) t
+  val can_cas_immediate : ('a, 'b) t -> reaction -> 'c offer option -> bool
 end
 
-module Make (Sched: Scheduler.S) : S
-  with type reaction = Reaction.Make(Sched).t
-   and type 'a offer = 'a Offer.Make(Sched).t
+module Make (Sched : Scheduler.S) :
+  S
+    with type reaction = Reaction.Make(Sched).t
+     and type 'a offer = 'a Offer.Make(Sched).t

--- a/lib/countdown_latch.ml
+++ b/lib/countdown_latch.ml
@@ -1,23 +1,26 @@
 module type S = sig
   type t
-  type ('a,'b) reagent
-  val create     : int -> t
-  val get_count  : t -> (unit, int) reagent
-  val await      : t -> (unit, unit) reagent
+  type ('a, 'b) reagent
+
+  val create : int -> t
+  val get_count : t -> (unit, int) reagent
+  val await : t -> (unit, unit) reagent
   val count_down : t -> (unit, unit) reagent
 end
 
-module Make (Base : Base.S) : S
-  with type ('a,'b) reagent = ('a,'b) Base.t = struct
+module Make (Base : Base.S) : S with type ('a, 'b) reagent = ('a, 'b) Base.t =
+struct
+  type ('a, 'b) reagent = ('a, 'b) Base.t
 
-  type ('a,'b) reagent = ('a,'b) Base.t
-  module C = Counter.Make(Base)
-
+  module C = Counter.Make (Base)
   open Base
 
   type t = C.t
+
   let create = C.create
   let get_count = C.get
-  let count_down c = C.try_dec c >>= (fun _ -> constant ())
-  let await c = C.get c >>> lift_blocking (fun v -> if v = 0 then Some () else None)
+  let count_down c = C.try_dec c >>= fun _ -> constant ()
+
+  let await c =
+    C.get c >>> lift_blocking (fun v -> if v = 0 then Some () else None)
 end

--- a/lib/countdown_latch.mli
+++ b/lib/countdown_latch.mli
@@ -1,11 +1,11 @@
 module type S = sig
   type t
-  type ('a,'b) reagent
-  val create     : int -> t
-  val get_count  : t -> (unit, int) reagent
-  val await      : t -> (unit, unit) reagent
+  type ('a, 'b) reagent
+
+  val create : int -> t
+  val get_count : t -> (unit, int) reagent
+  val await : t -> (unit, unit) reagent
   val count_down : t -> (unit, unit) reagent
 end
 
-module Make (Base : Base.S) : S
-  with type ('a,'b) reagent = ('a,'b) Base.t
+module Make (Base : Base.S) : S with type ('a, 'b) reagent = ('a, 'b) Base.t

--- a/lib/counter.ml
+++ b/lib/counter.ml
@@ -16,26 +16,28 @@
 
 module type S = sig
   type t
-  type ('a,'b) reagent
-  val create  : int -> t
-  val get     : t -> (unit, int) reagent
-  val inc     : t -> (unit, int) reagent
-  val dec     : t -> (unit, int) reagent
+  type ('a, 'b) reagent
+
+  val create : int -> t
+  val get : t -> (unit, int) reagent
+  val inc : t -> (unit, int) reagent
+  val dec : t -> (unit, int) reagent
   val try_dec : t -> (unit, int option) reagent
 end
 
-module Make (Base : Base.S) : S
-  with type ('a,'b) reagent = ('a,'b) Base.t = struct
-
+module Make (Base : Base.S) : S with type ('a, 'b) reagent = ('a, 'b) Base.t =
+struct
   module Ref = Base.Ref
-  type ('a,'b) reagent = ('a,'b) Base.t
 
+  type ('a, 'b) reagent = ('a, 'b) Base.t
   type t = int Ref.ref
 
   let create init = Ref.mk_ref init
   let get r = Ref.read r
-  let inc r = Ref.upd r (fun i () -> Some (i+1,i))
-  let dec r = Ref.upd r (fun i () -> if i > 0 then Some (i-1,i) else None)
-  let try_dec r = Ref.upd r (fun i () ->
-    if i > 0 then Some (i-1,Some i) else Some (0, None))
+  let inc r = Ref.upd r (fun i () -> Some (i + 1, i))
+  let dec r = Ref.upd r (fun i () -> if i > 0 then Some (i - 1, i) else None)
+
+  let try_dec r =
+    Ref.upd r (fun i () ->
+        if i > 0 then Some (i - 1, Some i) else Some (0, None))
 end

--- a/lib/counter.mli
+++ b/lib/counter.mli
@@ -16,13 +16,13 @@
 
 module type S = sig
   type t
-  type ('a,'b) reagent
-  val create  : int -> t
-  val get     : t -> (unit, int) reagent
-  val inc     : t -> (unit, int) reagent
-  val dec     : t -> (unit, int) reagent
+  type ('a, 'b) reagent
+
+  val create : int -> t
+  val get : t -> (unit, int) reagent
+  val inc : t -> (unit, int) reagent
+  val dec : t -> (unit, int) reagent
   val try_dec : t -> (unit, int option) reagent
 end
 
-module Make (Base: Base.S) : S
-  with type ('a,'b) reagent = ('a,'b) Base.t
+module Make (Base : Base.S) : S with type ('a, 'b) reagent = ('a, 'b) Base.t

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
- (name        reagents)
+ (name reagents)
  (public_name reagents)
- (libraries   lockfree domainslib kcas))
+ (libraries lockfree domainslib kcas))

--- a/lib/elimination_stack.ml
+++ b/lib/elimination_stack.ml
@@ -16,37 +16,36 @@
 
 module type S = sig
   type 'a t
-  type ('a,'b) reagent
-  val create  : unit -> 'a t
-  val push    : 'a t -> ('a, unit) reagent
-  val pop     : 'a t -> (unit, 'a) reagent
+  type ('a, 'b) reagent
+
+  val create : unit -> 'a t
+  val push : 'a t -> ('a, unit) reagent
+  val pop : 'a t -> (unit, 'a) reagent
   val try_pop : 'a t -> (unit, 'a option) reagent
 end
 
-module Make (Base: Base.S) : S
-  with type ('a,'b) reagent = ('a,'b) Base.t = struct
+module Make (Base : Base.S) : S with type ('a, 'b) reagent = ('a, 'b) Base.t =
+struct
+  type ('a, 'b) reagent = ('a, 'b) Base.t
 
-  type ('a,'b) reagent = ('a,'b) Base.t
-
-  module TS = Treiber_stack.Make(Base)
+  module TS = Treiber_stack.Make (Base)
   module C = Base.Channel
   open Base
 
-  type 'a t =
-    {stack     : 'a TS.t;
-     elim_push : ('a,unit) C.endpoint;
-     elim_pop  : (unit,'a) C.endpoint}
+  type 'a t = {
+    stack : 'a TS.t;
+    elim_push : ('a, unit) C.endpoint;
+    elim_pop : (unit, 'a) C.endpoint;
+  }
 
   let create () =
-    let (elim_push, elim_pop) = C.mk_chan () in
+    let elim_push, elim_pop = C.mk_chan () in
     { stack = TS.create (); elim_push; elim_pop }
 
   let push r = TS.push r.stack <+> C.swap r.elim_push
-
   let pop r = TS.pop r.stack <+> C.swap r.elim_pop
 
   let try_pop r =
-    let side_chan = C.swap r.elim_pop >>= (fun x -> constant (Some x)) in
+    let side_chan = C.swap r.elim_pop >>= fun x -> constant (Some x) in
     TS.try_pop r.stack <+> side_chan
-
 end

--- a/lib/elimination_stack.mli
+++ b/lib/elimination_stack.mli
@@ -16,12 +16,12 @@
 
 module type S = sig
   type 'a t
-  type ('a,'b) reagent
-  val create  : unit -> 'a t
-  val push    : 'a t -> ('a, unit) reagent
-  val pop     : 'a t -> (unit, 'a) reagent
+  type ('a, 'b) reagent
+
+  val create : unit -> 'a t
+  val push : 'a t -> ('a, unit) reagent
+  val pop : 'a t -> (unit, 'a) reagent
   val try_pop : 'a t -> (unit, 'a option) reagent
 end
 
-module Make (Base: Base.S) : S
-  with type ('a,'b) reagent = ('a,'b) Base.t
+module Make (Base : Base.S) : S with type ('a, 'b) reagent = ('a, 'b) Base.t

--- a/lib/exchanger.ml
+++ b/lib/exchanger.ml
@@ -3,20 +3,21 @@
 
 module type S = sig
   type 'a t
-  type ('a,'b) reagent
-  val create   : ?name:string -> unit -> 'a t
-  val exchange : 'a t -> ('a,'a) reagent
+  type ('a, 'b) reagent
+
+  val create : ?name:string -> unit -> 'a t
+  val exchange : 'a t -> ('a, 'a) reagent
 end
 
-module Make (Base : Base.S) : S
-  with type ('a,'b) reagent = ('a,'b) Base.t = struct
+module Make (Base : Base.S) : S with type ('a, 'b) reagent = ('a, 'b) Base.t =
+struct
+  type ('a, 'b) reagent = ('a, 'b) Base.t
 
-  type ('a,'b) reagent = ('a,'b) Base.t
   module C = Base.Channel
   open Base
 
-  type 'a t = ('a,'a) C.endpoint * ('a,'a) C.endpoint
+  type 'a t = ('a, 'a) C.endpoint * ('a, 'a) C.endpoint
 
-  let create = C.mk_chan 
+  let create = C.mk_chan
   let exchange e = C.swap (fst e) <+> C.swap (snd e)
 end

--- a/lib/exchanger.mli
+++ b/lib/exchanger.mli
@@ -1,9 +1,9 @@
 module type S = sig
   type 'a t
-  type ('a,'b) reagent
-  val create   : ?name:string -> unit -> 'a t
-  val exchange : 'a t -> ('a,'a) reagent
+  type ('a, 'b) reagent
+
+  val create : ?name:string -> unit -> 'a t
+  val exchange : 'a t -> ('a, 'a) reagent
 end
 
-module Make (Base : Base.S) : S
-  with type ('a,'b) reagent = ('a,'b) Base.t
+module Make (Base : Base.S) : S with type ('a, 'b) reagent = ('a, 'b) Base.t

--- a/lib/lock.ml
+++ b/lib/lock.ml
@@ -1,38 +1,37 @@
 module type S = sig
-  type ('a,'b) reagent
+  type ('a, 'b) reagent
   type t
 
-  val create  : unit -> t
-  val acq     : t -> (unit, unit) reagent
+  val create : unit -> t
+  val acq : t -> (unit, unit) reagent
   val try_acq : t -> (unit, bool) reagent
-  val rel     : t -> (unit, bool) reagent
+  val rel : t -> (unit, bool) reagent
 end
 
-module Make (Base: Base.S) : S
-  with type ('a,'b) reagent = ('a,'b) Base.t = struct
-
-  type ('a,'b) reagent = ('a,'b) Base.t
+module Make (Base : Base.S) : S with type ('a, 'b) reagent = ('a, 'b) Base.t =
+struct
+  type ('a, 'b) reagent = ('a, 'b) Base.t
 
   open Base
 
   type status = Locked | Unlocked
-
   type t = status Ref.ref
 
   let create () = Ref.mk_ref Unlocked
 
-  let acq r = Ref.upd r (fun s () ->
-    match s with
-    | Unlocked -> Some (Locked, ())
-    | Locked -> None)
+  let acq r =
+    Ref.upd r (fun s () ->
+        match s with Unlocked -> Some (Locked, ()) | Locked -> None)
 
-  let rel r = Ref.upd r (fun s () ->
-    match s with
-    | Locked -> Some (Unlocked, true)
-    | Unlocked -> Some (Unlocked, false))
+  let rel r =
+    Ref.upd r (fun s () ->
+        match s with
+        | Locked -> Some (Unlocked, true)
+        | Unlocked -> Some (Unlocked, false))
 
-  let try_acq r = Ref.upd r (fun s () ->
-    match s with
-    | Unlocked -> Some (Locked, true)
-    | Locked -> Some (Locked, false))
+  let try_acq r =
+    Ref.upd r (fun s () ->
+        match s with
+        | Unlocked -> Some (Locked, true)
+        | Locked -> Some (Locked, false))
 end

--- a/lib/lock.mli
+++ b/lib/lock.mli
@@ -1,14 +1,13 @@
 module type S = sig
-  type ('a,'b) reagent
+  type ('a, 'b) reagent
   type t
 
-  val create  : unit -> t
-  val acq     : t -> (unit, unit) reagent
+  val create : unit -> t
+  val acq : t -> (unit, unit) reagent
   val try_acq : t -> (unit, bool) reagent
 
-  val rel     : t -> (unit, bool) reagent
+  val rel : t -> (unit, bool) reagent
   (** [run (rel l) ()] returns [false] if the lock is not currently held. *)
 end
 
-module Make (Base: Base.S) : S
-  with type ('a,'b) reagent = ('a,'b) Base.t
+module Make (Base : Base.S) : S with type ('a, 'b) reagent = ('a, 'b) Base.t

--- a/lib/michaelScott_queue.ml
+++ b/lib/michaelScott_queue.ml
@@ -16,58 +16,60 @@
 
 module type S = sig
   type 'a t
-  type ('a,'b) reagent
-  val create  : unit -> 'a t
-  val push    : 'a t -> ('a, unit) reagent
-  val pop     : 'a t -> (unit, 'a) reagent
+  type ('a, 'b) reagent
+
+  val create : unit -> 'a t
+  val push : 'a t -> ('a, unit) reagent
+  val pop : 'a t -> (unit, 'a) reagent
   val try_pop : 'a t -> (unit, 'a option) reagent
 end
 
-module Make (Base: Base.S) : S
-  with type ('a,'b) reagent = ('a,'b) Base.t = struct
-
-  type ('a,'b) reagent = ('a,'b) Base.t
+module Make (Base : Base.S) : S with type ('a, 'b) reagent = ('a, 'b) Base.t =
+struct
+  type ('a, 'b) reagent = ('a, 'b) Base.t
 
   module Ref = Base.Ref
   open Base
 
-  type 'a node =
-    | Nil
-    | Next of 'a * 'a node Ref.ref
-
+  type 'a node = Nil | Next of 'a * 'a node Ref.ref
   type 'a t = { head : 'a node Ref.ref; tail : 'a node Ref.ref }
 
   let create () =
     let init_sentinal = Next (Obj.magic (), Ref.mk_ref Nil) in
     { head = Ref.mk_ref init_sentinal; tail = Ref.mk_ref init_sentinal }
 
-  let pop q = Ref.upd q.head (fun s () ->
-    match s with
-    | Nil -> failwith "MSQueue.pop: impossible"
-    | Next (_,x) ->
-        ( match Ref.read_imm x with
-          | Nil -> None
-          | Next (v,_) as n -> Some (n,v)))
+  let pop q =
+    Ref.upd q.head (fun s () ->
+        match s with
+        | Nil -> failwith "MSQueue.pop: impossible"
+        | Next (_, x) -> (
+            match Ref.read_imm x with
+            | Nil -> None
+            | Next (v, _) as n -> Some (n, v)))
 
-  let try_pop q = Ref.upd q.head (fun s () ->
-    match s with
-    | Nil -> failwith "MSQueue.try_pop: impossible"
-    | Next (_,x) as n ->
-        ( match Ref.read_imm x with
-          | Nil -> Some (n, None)
-          | Next (v,_) as n -> Some (n, Some v)))
+  let try_pop q =
+    Ref.upd q.head (fun s () ->
+        match s with
+        | Nil -> failwith "MSQueue.try_pop: impossible"
+        | Next (_, x) as n -> (
+            match Ref.read_imm x with
+            | Nil -> Some (n, None)
+            | Next (v, _) as n -> Some (n, Some v)))
 
   let rec find_and_enq n tail =
     match Ref.read_imm tail with
     | Nil -> failwith "MSQueue.push: impossible"
-    | Next (_,r) as ov ->
+    | Next (_, r) as ov -> (
         let s = Ref.read_imm r in
         let fwd_tail nv () = ignore @@ Ref.cas_imm tail ov nv in
         match s with
         | Nil -> Ref.cas r s n >>> post_commit (fwd_tail n)
-        | Next (_,_) as nv -> ( fwd_tail nv (); find_and_enq n tail )
+        | Next (_, _) as nv ->
+            fwd_tail nv ();
+            find_and_enq n tail)
 
-  let push q = return (fun x ->
-    let new_node = Next (x, Ref.mk_ref Nil) in
-    find_and_enq new_node q.tail)
+  let push q =
+    return (fun x ->
+        let new_node = Next (x, Ref.mk_ref Nil) in
+        find_and_enq new_node q.tail)
 end

--- a/lib/michaelScott_queue.mli
+++ b/lib/michaelScott_queue.mli
@@ -16,12 +16,12 @@
 
 module type S = sig
   type 'a t
-  type ('a,'b) reagent
-  val create  : unit -> 'a t
-  val push    : 'a t -> ('a, unit) reagent
-  val pop     : 'a t -> (unit, 'a) reagent
+  type ('a, 'b) reagent
+
+  val create : unit -> 'a t
+  val push : 'a t -> ('a, unit) reagent
+  val pop : 'a t -> (unit, 'a) reagent
   val try_pop : 'a t -> (unit, 'a option) reagent
 end
 
-module Make (Base: Base.S) : S
-  with type ('a,'b) reagent = ('a,'b) Base.t
+module Make (Base : Base.S) : S with type ('a, 'b) reagent = ('a, 'b) Base.t

--- a/lib/offer.ml
+++ b/lib/offer.ml
@@ -17,18 +17,18 @@
 
 module type S = sig
   type 'a t
-  val make       : unit -> 'a t
-  val equal      : 'a t -> 'b t -> bool
-  val is_active  : 'a t -> bool
-  val get_id     : 'a t -> int
-  val wait       : 'a t -> unit
-  val complete   : 'a t -> 'a -> PostCommitCas.t
-  val rescind    : 'a t -> 'a option
+
+  val make : unit -> 'a t
+  val equal : 'a t -> 'b t -> bool
+  val is_active : 'a t -> bool
+  val get_id : 'a t -> int
+  val wait : 'a t -> unit
+  val complete : 'a t -> 'a -> PostCommitCas.t
+  val rescind : 'a t -> 'a option
   val get_result : 'a t -> 'a option
 end
 
 module Make (Sched : Scheduler.S) : S = struct
-
   type 'a status =
     | Empty
     | Waiting of unit Sched.cont
@@ -38,61 +38,56 @@ module Make (Sched : Scheduler.S) : S = struct
   type 'a t = 'a status Kcas.ref
 
   let make () = Kcas.ref Empty
-
   let get_id r = Kcas.get_id r
-
   let equal o1 o2 = get_id o1 = get_id o2
 
-  let is_active o = match Kcas.get o with
+  let is_active o =
+    match Kcas.get o with
     | Empty | Waiting _ -> true
     | Rescinded | Completed _ -> false
 
-  let wait r = Sched.suspend (fun k ->
-    let cas_result =
-      Kcas.map r (fun v ->
-        match v with
-        | Empty -> Some (Waiting k)
-        | Waiting _ -> failwith "Offer.wait(1)"
-        | Completed _ | Rescinded -> None)
-    in
-    match cas_result with
-    (* If CAS was a success, then it is no longer this thread's responsibiliy to
-     * resume itself. *)
-    | Kcas.Success _ -> None
-    (* If the CAS failed, then another thread has already changed the offer from
-     * [Empty] to [Completed] or [Rescinded]. In this case, thread shouldn't
-     * wait. *)
-    | Kcas.Aborted -> Some ()
-    | Kcas.Failed  -> failwith "Offer.wait(2)")
+  let wait r =
+    Sched.suspend (fun k ->
+        let cas_result =
+          Kcas.map r (fun v ->
+              match v with
+              | Empty -> Some (Waiting k)
+              | Waiting _ -> failwith "Offer.wait(1)"
+              | Completed _ | Rescinded -> None)
+        in
+        match cas_result with
+        (* If CAS was a success, then it is no longer this thread's responsibiliy to
+         * resume itself. *)
+        | Kcas.Success _ -> None
+        (* If the CAS failed, then another thread has already changed the offer from
+         * [Empty] to [Completed] or [Rescinded]. In this case, thread shouldn't
+         * wait. *)
+        | Kcas.Aborted -> Some ()
+        | Kcas.Failed -> failwith "Offer.wait(2)")
 
   let complete r new_v =
     let old_v = Kcas.get r in
     match old_v with
     | Waiting k ->
-        PostCommitCas.cas r old_v (Completed new_v) (fun () -> Sched.resume k ())
-    | Empty ->
-        PostCommitCas.cas r old_v (Completed new_v) (fun () -> ())
+        PostCommitCas.cas r old_v (Completed new_v) (fun () ->
+            Sched.resume k ())
+    | Empty -> PostCommitCas.cas r old_v (Completed new_v) (fun () -> ())
     | Rescinded | Completed _ -> PostCommitCas.return false (fun () -> ())
 
   let rescind r =
     let cas_result =
       Kcas.map r (fun v ->
-        match v with
-        | Empty | Waiting _ -> Some Rescinded
-        | Rescinded | Completed _ -> None)
+          match v with
+          | Empty | Waiting _ -> Some Rescinded
+          | Rescinded | Completed _ -> None)
     in
-    ( begin
-        match cas_result with
-        | Kcas.Success (Waiting t) -> Sched.resume t ()
-        | _ -> ()
-      end;
-      match Kcas.get r with
-      | Rescinded -> None
-      | Completed v -> Some v
-      | _ -> failwith "Offer.rescind")
-
-  let get_result r =
+    (match cas_result with
+    | Kcas.Success (Waiting t) -> Sched.resume t ()
+    | _ -> ());
     match Kcas.get r with
+    | Rescinded -> None
     | Completed v -> Some v
-    | _ -> None
+    | _ -> failwith "Offer.rescind"
+
+  let get_result r = match Kcas.get r with Completed v -> Some v | _ -> None
 end

--- a/lib/offer.mli
+++ b/lib/offer.mli
@@ -17,13 +17,14 @@
 
 module type S = sig
   type 'a t
-  val make       : unit -> 'a t
-  val equal      : 'a t -> 'b t -> bool
-  val is_active  : 'a t -> bool
-  val get_id     : 'a t -> int
-  val wait       : 'a t -> unit
-  val complete   : 'a t -> 'a -> PostCommitCas.t
-  val rescind    : 'a t -> 'a option
+
+  val make : unit -> 'a t
+  val equal : 'a t -> 'b t -> bool
+  val is_active : 'a t -> bool
+  val get_id : 'a t -> int
+  val wait : 'a t -> unit
+  val complete : 'a t -> 'a -> PostCommitCas.t
+  val rescind : 'a t -> 'a option
   val get_result : 'a t -> 'a option
 end
 

--- a/lib/postCommitCas.mli
+++ b/lib/postCommitCas.mli
@@ -15,12 +15,14 @@
  *)
 
 type 'a ref = 'a Kcas.ref
+
 val ref : 'a -> 'a ref
 val get : 'a ref -> 'a
 
 type t
-val return    : bool -> (unit -> unit) -> t
-val cas       : 'a ref -> 'a -> 'a -> (unit -> unit) -> t
+
+val return : bool -> (unit -> unit) -> t
+val cas : 'a ref -> 'a -> 'a -> (unit -> unit) -> t
 val is_on_ref : t -> 'a ref -> bool
-val commit    : t -> (unit -> unit) option
-val kCAS      : t list -> (unit -> unit) option
+val commit : t -> (unit -> unit) option
+val kCAS : t list -> (unit -> unit) option

--- a/lib/reaction.ml
+++ b/lib/reaction.ml
@@ -17,38 +17,39 @@
 module type S = sig
   type t
   type 'a offer
+
   val empty : t
   val with_CAS : t -> PostCommitCas.t -> t
   val with_offer : t -> 'a offer -> t
   val try_commit : t -> bool
-  val cas_count  : t -> int
-  val has_offer  : t -> 'a offer -> bool
+  val cas_count : t -> int
+  val has_offer : t -> 'a offer -> bool
   val union : t -> t -> t
   val with_post_commit : t -> (unit -> unit) -> t
 end
 
-module Make (Sched: Scheduler.S) : S with type 'a offer = 'a Offer.Make(Sched).t = struct
-  module Offer = Offer.Make(Sched)
+module Make (Sched : Scheduler.S) :
+  S with type 'a offer = 'a Offer.Make(Sched).t = struct
+  module Offer = Offer.Make (Sched)
 
   type 'a offer = 'a Offer.t
 
   module IntSet = Set.Make (struct
     type t = int
+
     let compare = compare
   end)
 
-  type t =
-    { cases  : PostCommitCas.t list;
-      offers : IntSet.t;
-      post_commits : (unit -> unit) list }
+  type t = {
+    cases : PostCommitCas.t list;
+    offers : IntSet.t;
+    post_commits : (unit -> unit) list;
+  }
 
-  let empty = {cases = []; offers = IntSet.empty; post_commits = []}
-
-  let has_offer {offers; _} offer = IntSet.mem (Offer.get_id offer) offers
-
-  let with_CAS r cas = { r with cases = cas::r.cases }
-
-  let with_post_commit r pc = { r with post_commits = pc::r.post_commits }
+  let empty = { cases = []; offers = IntSet.empty; post_commits = [] }
+  let has_offer { offers; _ } offer = IntSet.mem (Offer.get_id offer) offers
+  let with_CAS r cas = { r with cases = cas :: r.cases }
+  let with_post_commit r pc = { r with post_commits = pc :: r.post_commits }
 
   let with_offer r offer =
     { r with offers = IntSet.add (Offer.get_id offer) r.offers }
@@ -56,20 +57,22 @@ module Make (Sched: Scheduler.S) : S with type 'a offer = 'a Offer.Make(Sched).t
   let cas_count r = List.length r.cases
 
   let union r1 r2 =
-    { cases = r1.cases @ r2.cases;
+    {
+      cases = r1.cases @ r2.cases;
       offers = IntSet.union r1.offers r2.offers;
-      post_commits = r1.post_commits @ r2.post_commits }
+      post_commits = r1.post_commits @ r2.post_commits;
+    }
 
   let try_commit r =
     let do_post_commit r = function
       | None -> false
       | Some pc ->
-          (pc ();
-            List.iter (fun f -> f ()) r.post_commits;
-            true)
+          pc ();
+          List.iter (fun f -> f ()) r.post_commits;
+          true
     in
     match r.cases with
     | [] -> true
-    | [cas] -> do_post_commit r @@ PostCommitCas.commit cas
+    | [ cas ] -> do_post_commit r @@ PostCommitCas.commit cas
     | l -> do_post_commit r @@ PostCommitCas.kCAS l
 end

--- a/lib/reaction.mli
+++ b/lib/reaction.mli
@@ -17,14 +17,16 @@
 module type S = sig
   type t
   type 'a offer
+
   val empty : t
-  val with_CAS   : t -> PostCommitCas.t -> t
+  val with_CAS : t -> PostCommitCas.t -> t
   val with_offer : t -> 'a offer -> t
   val try_commit : t -> bool
-  val cas_count  : t -> int
-  val has_offer  : t -> 'a offer -> bool
-  val union      : t -> t -> t
+  val cas_count : t -> int
+  val has_offer : t -> 'a offer -> bool
+  val union : t -> t -> t
   val with_post_commit : t -> (unit -> unit) -> t
 end
 
-module Make (Sched: Scheduler.S) : S with type 'a offer = 'a Offer.Make(Sched).t
+module Make (Sched : Scheduler.S) :
+  S with type 'a offer = 'a Offer.Make(Sched).t

--- a/lib/reagents.ml
+++ b/lib/reagents.ml
@@ -16,71 +16,83 @@
 
 module type Scheduler = sig
   type 'a cont
+
   val suspend : ('a cont -> 'a option) -> 'a
-  val resume  : 'a cont -> 'a -> unit
+  val resume : 'a cont -> 'a -> unit
   val get_tid : unit -> int
 end
 
 module type S = sig
-  type ('a,'b) t
-  val never         : ('a,'b) t
-  val constant      : 'a -> ('b,'a) t
-  val post_commit   : ('a -> unit) -> ('a, 'a) t
-  val lift          : ('a -> 'b) -> ('a,'b) t
-  val lift_blocking : ('a -> 'b option) -> ('a,'b) t
-  val return        : ('a -> (unit, 'b) t) -> ('a,'b) t
-  val (>>=)         : ('a,'b) t -> ('b -> (unit,'c) t) -> ('a,'c) t
-  val (>>>)         : ('a,'b) t -> ('b,'c) t -> ('a,'c) t
-  val (<+>)         : ('a,'b) t -> ('a,'b) t -> ('a,'b) t
-  val (<*>)         : ('a,'b) t -> ('a,'c) t -> ('a, 'b * 'c) t
-  val attempt       : ('a,'b) t -> ('a, 'b option) t
-  val run           : ('a,'b) t -> 'a -> 'b
+  type ('a, 'b) t
 
-  module Ref : Ref.S with type ('a,'b) reagent = ('a,'b) t
-  module Channel : Channel.S with type ('a,'b) reagent = ('a,'b) t
+  val never : ('a, 'b) t
+  val constant : 'a -> ('b, 'a) t
+  val post_commit : ('a -> unit) -> ('a, 'a) t
+  val lift : ('a -> 'b) -> ('a, 'b) t
+  val lift_blocking : ('a -> 'b option) -> ('a, 'b) t
+  val return : ('a -> (unit, 'b) t) -> ('a, 'b) t
+  val ( >>= ) : ('a, 'b) t -> ('b -> (unit, 'c) t) -> ('a, 'c) t
+  val ( >>> ) : ('a, 'b) t -> ('b, 'c) t -> ('a, 'c) t
+  val ( <+> ) : ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t
+  val ( <*> ) : ('a, 'b) t -> ('a, 'c) t -> ('a, 'b * 'c) t
+  val attempt : ('a, 'b) t -> ('a, 'b option) t
+  val run : ('a, 'b) t -> 'a -> 'b
+
+  module Ref : Ref.S with type ('a, 'b) reagent = ('a, 'b) t
+  module Channel : Channel.S with type ('a, 'b) reagent = ('a, 'b) t
 
   module Data : sig
-    module Counter : Counter.S with type ('a,'b) reagent = ('a,'b) t
-    module Treiber_stack : Treiber_stack.S with type ('a,'b) reagent = ('a,'b) t
-    module Elimination_stack : Elimination_stack.S with type ('a,'b) reagent = ('a,'b) t
-    module MichaelScott_queue : MichaelScott_queue.S with type ('a,'b) reagent = ('a,'b) t
+    module Counter : Counter.S with type ('a, 'b) reagent = ('a, 'b) t
+
+    module Treiber_stack :
+      Treiber_stack.S with type ('a, 'b) reagent = ('a, 'b) t
+
+    module Elimination_stack :
+      Elimination_stack.S with type ('a, 'b) reagent = ('a, 'b) t
+
+    module MichaelScott_queue :
+      MichaelScott_queue.S with type ('a, 'b) reagent = ('a, 'b) t
   end
 
   module Sync : sig
-    module Countdown_latch : Countdown_latch.S with type ('a,'b) reagent = ('a,'b) t
-    module Exchanger : Exchanger.S with type ('a,'b) reagent = ('a,'b) t
-    module Lock : Lock.S with type ('a,'b) reagent = ('a,'b) t
-    module Recursive_lock (Tid : sig val get_tid : unit -> int end) : Recursive_lock.S
-      with type ('a,'b) reagent = ('a,'b) t
-    module Condition_variable : Condition_variable.S
-      with type ('a,'b) reagent = ('a,'b) t
-      and type lock  = Lock.t
+    module Countdown_latch :
+      Countdown_latch.S with type ('a, 'b) reagent = ('a, 'b) t
+
+    module Exchanger : Exchanger.S with type ('a, 'b) reagent = ('a, 'b) t
+    module Lock : Lock.S with type ('a, 'b) reagent = ('a, 'b) t
+
+    module Recursive_lock (Tid : sig
+      val get_tid : unit -> int
+    end) : Recursive_lock.S with type ('a, 'b) reagent = ('a, 'b) t
+
+    module Condition_variable :
+      Condition_variable.S
+        with type ('a, 'b) reagent = ('a, 'b) t
+         and type lock = Lock.t
   end
 end
 
-module Make (Sched: Scheduler) : S = struct
-
+module Make (Sched : Scheduler) : S = struct
   module B = struct
-    include Core.Make(Sched)
-    module Ref = Ref.Make(Sched)
-    module Channel = Channel.Make(Sched)
+    include Core.Make (Sched)
+    module Ref = Ref.Make (Sched)
+    module Channel = Channel.Make (Sched)
   end
 
   include B
 
   module Data = struct
-    module Counter = Counter.Make(B)
-    module Treiber_stack = Treiber_stack.Make(B)
-    module Elimination_stack = Elimination_stack.Make(B)
-    module MichaelScott_queue = MichaelScott_queue.Make(B)
-
+    module Counter = Counter.Make (B)
+    module Treiber_stack = Treiber_stack.Make (B)
+    module Elimination_stack = Elimination_stack.Make (B)
+    module MichaelScott_queue = MichaelScott_queue.Make (B)
   end
 
   module Sync = struct
-    module Countdown_latch = Countdown_latch.Make(B)
-    module Exchanger = Exchanger.Make(B)
-    module Lock = Lock.Make(B)
-    module Recursive_lock = Recursive_lock.Make(B)
-    module Condition_variable = Condition_variable.Make(B)(Lock)
+    module Countdown_latch = Countdown_latch.Make (B)
+    module Exchanger = Exchanger.Make (B)
+    module Lock = Lock.Make (B)
+    module Recursive_lock = Recursive_lock.Make (B)
+    module Condition_variable = Condition_variable.Make (B) (Lock)
   end
 end

--- a/lib/reagents.mli
+++ b/lib/reagents.mli
@@ -14,7 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-
 module type Scheduler = sig
   type 'a cont
   (** The type of continuation. *)
@@ -25,7 +24,7 @@ module type Scheduler = sig
       returns [None], then the current fiber is suspended and the control
       switches to the next fiber from the scheduler. *)
 
-  val resume  : 'a cont -> 'a -> unit
+  val resume : 'a cont -> 'a -> unit
   (** [resume k v] prepares to resume the continuation [k] with value [v] and
       enqueues the continuation to the scheduler queue. *)
 
@@ -34,79 +33,90 @@ module type Scheduler = sig
 end
 
 module type S = sig
-
-  type ('a,'b) t
+  type ('a, 'b) t
   (** The type of a reagent computation which accepts a value of type ['a] and
       returns a value of type ['b]. *)
 
-  val never : ('a,'b) t
+  val never : ('a, 'b) t
   (** A reagent that is never enabled. *)
 
-  val constant : 'a -> ('b,'a) t
+  val constant : 'a -> ('b, 'a) t
   (** [constant v] is a reagent that always returns [v]. *)
 
   val post_commit : ('a -> unit) -> ('a, 'a) t
   (** [post_commit f] returns a reagent [r] that runs [f r] after the reagent
       [r] (or any reagent constructed using [r]) commits. *)
 
-  val lift : ('a -> 'b) -> ('a,'b) t
+  val lift : ('a -> 'b) -> ('a, 'b) t
   (** [lift f] lifts a pure function [f] to a reagent. If [f] includes
       side-effects, then the side-effects may be performed zero or more times.
       It is expected that [f] does not perform any blocking operations. *)
 
-  val lift_blocking : ('a -> 'b option) -> ('a,'b) t
+  val lift_blocking : ('a -> 'b option) -> ('a, 'b) t
   (** [lift_blocking f] blocks if [f] returns [None]. Otherwise, it behaves
       like {!lift}. *)
 
-  val return : ('a -> (unit, 'b) t) -> ('a,'b) t
+  val return : ('a -> (unit, 'b) t) -> ('a, 'b) t
   (** The monadic return primitive for reagents. *)
 
-  val (>>=) : ('a,'b) t -> ('b -> (unit,'c) t) -> ('a,'c) t
+  val ( >>= ) : ('a, 'b) t -> ('b -> (unit, 'c) t) -> ('a, 'c) t
   (** The monadic bind primitive for reagents. *)
 
-  val (>>>) : ('a,'b) t -> ('b,'c) t -> ('a,'c) t
+  val ( >>> ) : ('a, 'b) t -> ('b, 'c) t -> ('a, 'c) t
   (** The sequential composition operator. [a >>> b] perform [a] and [b]
       atomically. Corresponds to arrow bind. *)
 
-  val (<+>) : ('a,'b) t -> ('a,'b) t -> ('a,'b) t
+  val ( <+> ) : ('a, 'b) t -> ('a, 'b) t -> ('a, 'b) t
   (** Left-biased choice. [a <+> b] first attempts [a]. If [a] blocks, then [b]
       is attempted. If both of them block, then the whole protocol blocks. *)
 
-  val (<*>) : ('a,'b) t -> ('a,'c) t -> ('a, 'b * 'c) t
+  val ( <*> ) : ('a, 'b) t -> ('a, 'c) t -> ('a, 'b * 'c) t
   (** Parallel composition operator. [a <*> b] is only enabled if both [a] and
       [b] are enabled. *)
 
-  val attempt : ('a,'b) t -> ('a, 'b option) t
+  val attempt : ('a, 'b) t -> ('a, 'b option) t
   (** Convert a blocking reagent into a non-blocking one. If reagent [r] is a
       blocks, then [attempt r] return [None]. If [r] does not block and returns
       a value [v], then [attempt r] returns [Some v]. *)
 
-  val run : ('a,'b) t -> 'a -> 'b
+  val run : ('a, 'b) t -> 'a -> 'b
   (** [run r v] runs the reagents [r] with value [v]. *)
 
-  module Ref : Ref.S with type ('a,'b) reagent = ('a,'b) t
+  module Ref : Ref.S with type ('a, 'b) reagent = ('a, 'b) t
   (** Shared memory references. *)
 
-  module Channel : Channel.S with type ('a,'b) reagent = ('a,'b) t
+  module Channel : Channel.S with type ('a, 'b) reagent = ('a, 'b) t
   (** Synchronous message-passing channels. *)
 
   module Data : sig
-    module Counter : Counter.S with type ('a,'b) reagent = ('a,'b) t
-    module Treiber_stack : Treiber_stack.S with type ('a,'b) reagent = ('a,'b) t
-    module Elimination_stack : Elimination_stack.S with type ('a,'b) reagent = ('a,'b) t
-    module MichaelScott_queue : MichaelScott_queue.S with type ('a,'b) reagent = ('a,'b) t
+    module Counter : Counter.S with type ('a, 'b) reagent = ('a, 'b) t
+
+    module Treiber_stack :
+      Treiber_stack.S with type ('a, 'b) reagent = ('a, 'b) t
+
+    module Elimination_stack :
+      Elimination_stack.S with type ('a, 'b) reagent = ('a, 'b) t
+
+    module MichaelScott_queue :
+      MichaelScott_queue.S with type ('a, 'b) reagent = ('a, 'b) t
   end
 
   module Sync : sig
-    module Countdown_latch : Countdown_latch.S with type ('a,'b) reagent = ('a,'b) t
-    module Exchanger : Exchanger.S with type ('a,'b) reagent = ('a,'b) t
-    module Lock : Lock.S with type ('a,'b) reagent = ('a,'b) t
-    module Recursive_lock (Tid : sig val get_tid : unit -> int end) : Recursive_lock.S
-      with type ('a,'b) reagent = ('a,'b) t
-    module Condition_variable : Condition_variable.S
-      with type ('a,'b) reagent = ('a,'b) t
-      and type lock  = Lock.t
+    module Countdown_latch :
+      Countdown_latch.S with type ('a, 'b) reagent = ('a, 'b) t
+
+    module Exchanger : Exchanger.S with type ('a, 'b) reagent = ('a, 'b) t
+    module Lock : Lock.S with type ('a, 'b) reagent = ('a, 'b) t
+
+    module Recursive_lock (Tid : sig
+      val get_tid : unit -> int
+    end) : Recursive_lock.S with type ('a, 'b) reagent = ('a, 'b) t
+
+    module Condition_variable :
+      Condition_variable.S
+        with type ('a, 'b) reagent = ('a, 'b) t
+         and type lock = Lock.t
   end
 end
 
-module Make (Sched: Scheduler) : S
+module Make (Sched : Scheduler) : S

--- a/lib/recursive_lock.ml
+++ b/lib/recursive_lock.ml
@@ -1,18 +1,18 @@
 module type S = sig
-  type ('a,'b) reagent
+  type ('a, 'b) reagent
   type t
 
-  val create  : unit -> t
-  val acq     : t -> (unit, unit) reagent
+  val create : unit -> t
+  val acq : t -> (unit, unit) reagent
   val try_acq : t -> (unit, bool) reagent
-  val rel     : t -> (unit, bool) reagent
+  val rel : t -> (unit, bool) reagent
 end
 
-module Make (Base: Base.S)
-            (Tid : sig val get_tid : unit -> int end) : S
-  with type ('a,'b) reagent = ('a,'b) Base.t = struct
-
-  type ('a,'b) reagent = ('a,'b) Base.t
+module Make
+    (Base : Base.S) (Tid : sig
+      val get_tid : unit -> int
+    end) : S with type ('a, 'b) reagent = ('a, 'b) Base.t = struct
+  type ('a, 'b) reagent = ('a, 'b) Base.t
 
   open Base
 
@@ -26,47 +26,38 @@ module Make (Base: Base.S)
 
   let create () = Ref.mk_ref Unlocked
 
-  let acq r = Ref.upd r (fun s () ->
-    let tid = Tid.get_tid () in
-    match s with
-    | Unlocked ->
-       (* No current owner, take the lock *)
-       Some (Locked (tid, 1), ())
-    | Locked (owner, count) ->
-       begin
-         if owner = tid then
-           Some (Locked (tid, count + 1), ())
-         else
-           None
-       end)
+  let acq r =
+    Ref.upd r (fun s () ->
+        let tid = Tid.get_tid () in
+        match s with
+        | Unlocked ->
+            (* No current owner, take the lock *)
+            Some (Locked (tid, 1), ())
+        | Locked (owner, count) ->
+            if owner = tid then Some (Locked (tid, count + 1), ()) else None)
 
-  let rel r = Ref.upd r (fun s () ->
-    let tid = Tid.get_tid () in
-    match s with
-    | Unlocked -> Some (Unlocked, false)
-    | Locked (owner, count) ->
-       begin
-         if owner = tid then
-           let new_count = count - 1 in
-           if new_count = 0 then
-             Some (Unlocked, true)
-           else
-             Some (Locked (tid, new_count), true)
-         else
-           Some (Locked (owner, count), false)
-       end)
+  let rel r =
+    Ref.upd r (fun s () ->
+        let tid = Tid.get_tid () in
+        match s with
+        | Unlocked -> Some (Unlocked, false)
+        | Locked (owner, count) ->
+            if owner = tid then
+              let new_count = count - 1 in
+              if new_count = 0 then Some (Unlocked, true)
+              else Some (Locked (tid, new_count), true)
+            else Some (Locked (owner, count), false))
 
-  let try_acq r = Ref.upd r (fun s () ->
-    let tid = Tid.get_tid () in
-    match s with
-    | Unlocked -> Some (Locked (tid, 1), true)
-    | Locked (owner, count) ->
-       begin
-         if owner = tid then
-           (* Already the owner, increase lock count *)
-           Some (Locked (tid, count + 1), true)
-         else
-           (* Not the owner, don't wait on lock *)
-           Some (Locked (owner, count), false)
-       end)
+  let try_acq r =
+    Ref.upd r (fun s () ->
+        let tid = Tid.get_tid () in
+        match s with
+        | Unlocked -> Some (Locked (tid, 1), true)
+        | Locked (owner, count) ->
+            if owner = tid then
+              (* Already the owner, increase lock count *)
+              Some (Locked (tid, count + 1), true)
+            else
+              (* Not the owner, don't wait on lock *)
+              Some (Locked (owner, count), false))
 end

--- a/lib/recursive_lock.mli
+++ b/lib/recursive_lock.mli
@@ -1,16 +1,18 @@
 module type S = sig
-  type ('a,'b) reagent
+  type ('a, 'b) reagent
   type t
 
-  val create  : unit -> t
-  val acq     : t -> (unit, unit) reagent
+  val create : unit -> t
+  val acq : t -> (unit, unit) reagent
 
   val try_acq : t -> (unit, bool) reagent
   (** [run (try_acq l) ()] returns [true] if the lock was successful *)
 
-  val rel     : t -> (unit, bool) reagent
+  val rel : t -> (unit, bool) reagent
   (** [run (rel l) ()] returns [false] if the lock is either not held or held by another thread  *)
 end
 
-module Make (Base: Base.S) (Tid : sig val get_tid : unit -> int end) : S
-  with type ('a,'b) reagent = ('a,'b) Base.t
+module Make
+    (Base : Base.S) (Tid : sig
+      val get_tid : unit -> int
+    end) : S with type ('a, 'b) reagent = ('a, 'b) Base.t

--- a/lib/ref.mli
+++ b/lib/ref.mli
@@ -19,7 +19,7 @@ module type S = sig
   type 'a ref
   (** The type of shared memory reference. *)
 
-  type ('a,'b) reagent
+  type ('a, 'b) reagent
   (** The type of reagent. *)
 
   val mk_ref : 'a -> 'a ref
@@ -42,7 +42,7 @@ module type S = sig
   (** [cas_imm r e u] attempts to atomically update [r] from [e] to [u]. If
       successful, the function returns [true]. Otherwise, returns [false]. *)
 
-  val upd : 'a ref -> ('a -> 'b -> ('a *'c) option) -> ('b,'c) reagent
+  val upd : 'a ref -> ('a -> 'b -> ('a * 'c) option) -> ('b, 'c) reagent
   (** [upd r f] returns a reagent value which when run applies [f] to the
       current value [c] of the reference and the input value of the reagent. If
       [f] returns, [None] the protocol is retried. If [f] returns [Some v], the
@@ -53,5 +53,5 @@ module type S = sig
       suspended until there is a possibility of success. *)
 end
 
-module Make(Sched: Scheduler.S)
-  : S with type ('a,'b) reagent = ('a,'b) Core.Make(Sched).t
+module Make (Sched : Scheduler.S) :
+  S with type ('a, 'b) reagent = ('a, 'b) Core.Make(Sched).t

--- a/lib/scheduler.ml
+++ b/lib/scheduler.ml
@@ -17,7 +17,8 @@
 
 module type S = sig
   type 'a cont
+
   val suspend : ('a cont -> 'a option) -> 'a
-  val resume  : 'a cont -> 'a -> unit
+  val resume : 'a cont -> 'a -> unit
   val get_tid : unit -> int
 end

--- a/lib/scheduler.mli
+++ b/lib/scheduler.mli
@@ -17,7 +17,8 @@
 
 module type S = sig
   type 'a cont
+
   val suspend : ('a cont -> 'a option) -> 'a
-  val resume  : 'a cont -> 'a -> unit
+  val resume : 'a cont -> 'a -> unit
   val get_tid : unit -> int
 end

--- a/lib/treiber_stack.mli
+++ b/lib/treiber_stack.mli
@@ -16,12 +16,12 @@
 
 module type S = sig
   type 'a t
-  type ('a,'b) reagent
-  val create  : unit -> 'a t
-  val push    : 'a t -> ('a, unit) reagent
-  val pop     : 'a t -> (unit, 'a) reagent
+  type ('a, 'b) reagent
+
+  val create : unit -> 'a t
+  val push : 'a t -> ('a, unit) reagent
+  val pop : 'a t -> (unit, 'a) reagent
   val try_pop : 'a t -> (unit, 'a option) reagent
 end
 
-module Make (Base: Base.S) : S
-  with type ('a,'b) reagent = ('a,'b) Base.t
+module Make (Base : Base.S) : S with type ('a, 'b) reagent = ('a, 'b) Base.t


### PR DESCRIPTION
Mechanical changes: 
1. Create .ocamlformat 
2. Remove _formatting disabled_ from _dune-project_
3. dune build @fmt
4. dune promote

Using slightly older ocamlformat (0.23.0) than available (0.24.1) to avoid conflicts with `dune-release/odoc` on 5.0.0.