### PR TITLE
Upgrade to kcas 0.2.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -15,7 +15,7 @@
   (ocaml (>= 5.0))
   (lockfree (>= 0.3.0))
   domainslib
-  (kcas (>= 0.1.5))
+  (kcas (>= 0.2.0))
   alcotest)
  (synopsis "Composable lock-free data and synchronization structures")
  (description "Reagents - Composable lock-free data and synchronization structures"))

--- a/examples/dune
+++ b/examples/dune
@@ -40,7 +40,13 @@
 
 (test
  (name queue_test)
- (modules queue_test lock_queue two_lock_queue lock)
+ (modules
+  queue_test
+  lock_queue
+  two_lock_queue
+  lock
+  tx_linked_queue
+  tx_two_stack_queue)
  (libraries reagents sched_ws))
 
 (test

--- a/examples/queue_test.ml
+++ b/examples/queue_test.ml
@@ -95,6 +95,24 @@ module Test (Q : QUEUE) = struct
     Reagents.run (CDL.await b) ()
 end
 
+module MakeQ_tx (T : sig
+  open Kcas
+
+  type 'a t
+
+  val create : unit -> 'a t
+  val push : 'a t -> 'a -> unit Tx.t
+  val pop : 'a t -> 'a option Tx.t
+end) : QUEUE = struct
+  open Kcas
+
+  type 'a t = 'a T.t
+
+  let create = T.create
+  let push queue value = Tx.commit @@ T.push queue value
+  let pop queue = Tx.commit @@ T.pop queue
+end
+
 let main () =
   let module M = Test (Lock_queue) in
   let m, sd = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
@@ -104,6 +122,16 @@ let main () =
   let module M = Test (Two_lock_queue) in
   let m, sd = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
   Printf.printf "Two_lock_queue : mean = %f, sd = %f tp=%f\n%!" m sd
+    (float_of_int num_items /. m);
+
+  let module M = Test (MakeQ_tx (Tx_linked_queue)) in
+  let m, sd = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
+  Printf.printf "Kcas linked queue : mean = %f, sd = %f tp=%f\n%!" m sd
+    (float_of_int num_items /. m);
+
+  let module M = Test (MakeQ_tx (Tx_two_stack_queue)) in
+  let m, sd = Benchmark.benchmark (fun () -> M.run num_doms items_per_dom) 5 in
+  Printf.printf "Kcas 2-stack queue : mean = %f, sd = %f tp=%f\n%!" m sd
     (float_of_int num_items /. m);
 
   let module M = Test (MakeQ (Reagents.Data.MichaelScott_queue)) in

--- a/examples/tx_linked_queue.ml
+++ b/examples/tx_linked_queue.ml
@@ -1,0 +1,23 @@
+open Kcas
+
+type 'a t = { front : 'a node Loc.t; back : 'a node Loc.t }
+and 'a node = Nil | Node of 'a node Loc.t * 'a
+
+let create () = { front = Loc.make Nil; back = Loc.make Nil }
+
+let push queue value =
+  Tx.(
+    delay @@ fun () ->
+    let node = Node (Loc.make Nil, value) in
+    exchange queue.back node >>= function
+    | Nil -> set queue.front node
+    | Node (next, _) -> set next node)
+
+let pop queue =
+  Tx.(
+    get queue.front >>= function
+    | Nil -> return None
+    | Node (next, value) -> (
+        get next >>= function
+        | Nil -> set queue.front Nil >> set queue.back Nil >>. Some value
+        | node -> set queue.front node >>. Some value))

--- a/examples/tx_linked_queue.mli
+++ b/examples/tx_linked_queue.mli
@@ -1,0 +1,7 @@
+open Kcas
+
+type 'a t
+
+val create : unit -> 'a t
+val push : 'a t -> 'a -> unit Tx.t
+val pop : 'a t -> 'a option Tx.t

--- a/examples/tx_two_stack_queue.ml
+++ b/examples/tx_two_stack_queue.ml
@@ -1,0 +1,15 @@
+open Kcas
+
+type 'a t = { front : 'a list Loc.t; back : 'a list Loc.t }
+
+let create () = { front = Loc.make []; back = Loc.make [] }
+let push q x = Tx.modify q.front @@ List.cons x
+
+let pop q =
+  Tx.(
+    get q.front >>= function
+    | x :: xs -> set q.front xs >>. Some x
+    | [] -> (
+        get_as List.rev q.back >>= function
+        | [] -> return None
+        | x :: xs -> set q.back [] >> set q.front xs >>. Some x))

--- a/examples/tx_two_stack_queue.mli
+++ b/examples/tx_two_stack_queue.mli
@@ -1,0 +1,7 @@
+open Kcas
+
+type 'a t
+
+val create : unit -> 'a t
+val push : 'a t -> 'a -> unit Tx.t
+val pop : 'a t -> 'a option Tx.t

--- a/lib/postCommitCas.mli
+++ b/lib/postCommitCas.mli
@@ -14,7 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-type 'a ref = 'a Kcas.ref
+type 'a ref = 'a Kcas.Loc.t
 
 val ref : 'a -> 'a ref
 val get : 'a ref -> 'a

--- a/reagents.opam
+++ b/reagents.opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "5.0"}
   "lockfree" {>= "0.3.0"}
   "domainslib"
-  "kcas" {>= "0.1.5"}
+  "kcas" {>= "0.2.0"}
   "alcotest"
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
This PR:
* Upgrades Reagents to use kcas 0.2.0
* Adds two kcas Tx based queues to the queue benchmark for reference

A run of the `queue_test.exe` gave the following output on my Apple M1:

```
Lock_queue : mean = 0.027357, sd = 0.000060 tp=10966112.271185
Two_lock_queue : mean = 0.010363, sd = 0.000002 tp=28950193.263390
Kcas linked queue : mean = 0.026011, sd = 0.000014 tp=11533755.467641
Kcas 2-stack queue : mean = 0.011396, sd = 0.000000 tp=26325956.239565
Reagent Lockfree.MSQueue: mean = 0.042747, sd = 0.000001 tp=7018001.637527
Hand-written Lockfree.MSQueue: mean = 0.012231, sd = 0.000010 tp=24527806.692319
```

The timings vary slightly between runs, but it seems the 2-stack queue is very close to MS queue and the 2-lock queue.  Of course, as mentioned in the kcas introduction, the 2-stack queue has a [weakness](https://github.com/ocaml-multicore/kcas/#a-transactional-lock-free-queue), which can make it unsuitable for some use cases.