### PR TITLE
Change cas to use physical equality

### DIFF
--- a/lib/ref.ml
+++ b/lib/ref.ml
@@ -120,5 +120,5 @@ module Make (Sched : Scheduler.S) :
 
   let cas ?(never_block = false) r expect update =
     upd ~never_block r (fun current () ->
-        if current = expect then Some (update, ()) else None)
+        if current == expect then Some (update, ()) else None)
 end


### PR DESCRIPTION
While looking at https://github.com/ocaml-multicore/reagents/pull/41, I've discovered that Ref's compare and set uses structural equality. It is not the right default. 

Firstly, such a comparison is well-defined only on immutable structures. As soon as there's any mutability we have a race and there's no chance of catching it at compile time, since there's no means to enforce mutability. Note, the race occurs even if `'a Atomic.t` is used: 
```ocaml
(Atomic.make 0, Atomic.make 1) = (Atomic.make 0, Atomic.make 1);;
- : bool = true
```
For the same reason, the bug is going to be caught by intensive parallel tests only. 

Furthermore, structural comparison is surprising for anyone who's used to standard library atomics before.